### PR TITLE
fix: addrssing the vulnerability that came through where jsonwebtoken…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3834,7 +3834,7 @@
         "file-type": "^7.7.1",
         "form-data": "^2.3.3",
         "isstream": "~0.1.2",
-        "jsonwebtoken": "^9.0.0",
+        "jsonwebtoken": "^9.0.1",
         "lodash.isempty": "^4.4.0",
         "mime-types": "~2.1.18",
         "object.omit": "~3.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3834,7 +3834,7 @@
         "file-type": "^7.7.1",
         "form-data": "^2.3.3",
         "isstream": "~0.1.2",
-        "jsonwebtoken": "^8.5.1",
+        "jsonwebtoken": "^9.0.0",
         "lodash.isempty": "^4.4.0",
         "mime-types": "~2.1.18",
         "object.omit": "~3.0.0",
@@ -6482,8 +6482,8 @@
       }
     },
     "node_modules/jsonwebtoken": {
-      "version": "8.5.1",
-      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.0.tgz",
       "integrity": "sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==",
       "dependencies": {
         "jws": "^3.2.2",
@@ -15104,7 +15104,7 @@
         "file-type": "^7.7.1",
         "form-data": "^2.3.3",
         "isstream": "~0.1.2",
-        "jsonwebtoken": "^8.5.1",
+        "jsonwebtoken": "^9.0.0",
         "lodash.isempty": "^4.4.0",
         "mime-types": "~2.1.18",
         "object.omit": "~3.0.0",
@@ -17063,8 +17063,8 @@
       }
     },
     "jsonwebtoken": {
-      "version": "8.5.1",
-      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.0.tgz",
       "integrity": "sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==",
       "requires": {
         "jws": "^3.2.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3834,7 +3834,7 @@
         "file-type": "^7.7.1",
         "form-data": "^2.3.3",
         "isstream": "~0.1.2",
-        "jsonwebtoken": "^9.0.1",
+        "jsonwebtoken": "^9.0.0",
         "lodash.isempty": "^4.4.0",
         "mime-types": "~2.1.18",
         "object.omit": "~3.0.0",


### PR DESCRIPTION
… needs to be upgraded

dependency: none

## PR summary
the following problem was detected in our weekly scans. 
<img width="1189" alt="image" src="https://user-images.githubusercontent.com/39170034/209893000-2e343486-e607-4d71-b7c3-8f5d5c1b29c3.png">


As a result, I've tweaked the package-lock.json file to bump the version numbers. 

**Fixes:**  https://github.com/IBM/networking-node-sdk/security/dependabot/36

## PR Checklist
Please make sure that your PR fulfills the following requirements:
- [ ] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [ ] Build/CI related changes
- [ ] Documentation content changes
- [x] Other (please describe) - dependency version update

## What is the current behavior?
Vulnerability scan is generating an alert suggesting a dependency package called jsonwebtoken needs to be updated from version 

## What is the new behavior?
Vulnerability scan should be updated from 8.5.1 to 9.0.0

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
<!-- Please add any additional information that would help reviewers evaluate your PR -->
