### PR TITLE
fix(node16-18): add node 16 and 18 like platform node sdk repo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ sudo: false
 
 node_js:
 - 14
+- 16
+- 18
 
 before_install:
 - echo -e "machine github.ibm.com\n  login $GH_TOKEN" > ~/.netrc

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+dist: jammy
+
 language: node_js
 
 sudo: false
@@ -14,8 +16,6 @@ before_install:
 - '[ "${TRAVIS_PULL_REQUEST}" == "false" ] && openssl aes-256-cbc -K $encrypted_fc092b9428d6_key -iv $encrypted_fc092b9428d6_iv -in cis.env.enc -out cis.env -d || true'
 - '[ "${TRAVIS_PULL_REQUEST}" == "false" ] && openssl aes-256-cbc -K $encrypted_fb1b85a9795b_key -iv $encrypted_fb1b85a9795b_iv -in cislog.env.enc -out cislog.env -d || true'
 - '[ "${TRAVIS_PULL_REQUEST}" == "false" ] && openssl aes-256-cbc -K $encrypted_89a9eb4f9417_key -iv $encrypted_89a9eb4f9417_iv -in dns.env.enc -out dns.env -d || true'
-- npm i -g npm@8
-- npm --version
 
 script:
 - npm run build

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,8 @@ before_install:
 - '[ "${TRAVIS_PULL_REQUEST}" == "false" ] && openssl aes-256-cbc -K $encrypted_fc092b9428d6_key -iv $encrypted_fc092b9428d6_iv -in cis.env.enc -out cis.env -d || true'
 - '[ "${TRAVIS_PULL_REQUEST}" == "false" ] && openssl aes-256-cbc -K $encrypted_fb1b85a9795b_key -iv $encrypted_fb1b85a9795b_iv -in cislog.env.enc -out cislog.env -d || true'
 - '[ "${TRAVIS_PULL_REQUEST}" == "false" ] && openssl aes-256-cbc -K $encrypted_89a9eb4f9417_key -iv $encrypted_89a9eb4f9417_iv -in dns.env.enc -out dns.env -d || true'
+- npm i -g npm@8
+- npm --version
 
 script:
 - npm run build


### PR DESCRIPTION
## PR summary
This PR enables the CI build to be compatible with newer versions of node.js; in this case versions 16 and 18.
This PR arose from a discussion in this PR: IBM/networking-node-sdk#100
The xenial ubuntu version does not support node.js 18. Therefore, the ubuntu distribution in the travis CI was set to `jammy`. as used in the following SDK repo: https://github.com/IBM/platform-services-node-sdk
Jammy Jellyfish (Ubuntu 22.04) documentation: https://docs.travis-ci.com/user/reference/jammy/#javascript-and-nodejs-support
## PR Checklist
Please make sure that your PR fulfills the following requirements:
- [x] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [ ] Build/CI related changes
- [ ] Documentation content changes
- [x] Other (please describe)

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

## What is the new behavior?
<!-- Please describe the new behavior after your change. -->

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
<!-- Please add any additional information that would help reviewers evaluate your PR -->
