### PR TITLE
feat(logpush): regenerate SDK and add comprehensive integration tests

### DIFF
--- a/cis/logpushjobsapiv1/v1.ts
+++ b/cis/logpushjobsapiv1/v1.ts
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corp. 2022.
+ * (C) Copyright IBM Corp. 2026.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,22 +15,23 @@
  */
 
 /**
- * IBM OpenAPI SDK Code Generator Version: 3.48.0-e80b60a1-20220414-145125
+ * IBM OpenAPI SDK Code Generator Version: 3.114.0-a902401e-20260427-192904
  */
 
 import * as extend from 'extend';
 import { IncomingHttpHeaders, OutgoingHttpHeaders } from 'http';
 import {
+  AbortSignal,
   Authenticator,
   BaseService,
-  getAuthenticatorFromEnvironment,
   UserOptions,
+  getAuthenticatorFromEnvironment,
   validateParams,
 } from 'ibm-cloud-sdk-core';
 import { getSdkHeaders } from '../../lib/common';
 
 /**
- * CIS Loupush Jobs
+ * CIS Logpush Jobs
  *
  * API Version: 1.0.0
  */
@@ -50,7 +51,7 @@ class LogpushJobsApiV1 extends BaseService {
    * @param {UserOptions} [options] - The parameters to send to the service.
    * @param {string} [options.serviceName] - The name of the service to configure
    * @param {Authenticator} [options.authenticator] - The Authenticator object used to authenticate requests to the service
-   * @param {string} [options.serviceUrl] - The URL for the service
+   * @param {string} [options.serviceUrl] - The base URL for the service
    * @returns {LogpushJobsApiV1}
    */
 
@@ -71,23 +72,23 @@ class LogpushJobsApiV1 extends BaseService {
     return service;
   }
 
-  /** Full url-encoded CRN of the service instance. */
+  /** Full URL-encoded CRN of the service instance. */
   crn: string;
-
-  /** The domain id. */
-  zoneId: string;
 
   /** The dataset. */
   dataset: string;
+
+  /** Zone identifier. */
+  zoneId: string;
 
   /**
    * Construct a LogpushJobsApiV1 object.
    *
    * @param {Object} options - Options for the service.
-   * @param {string} options.crn - Full url-encoded CRN of the service instance.
-   * @param {string} options.zoneId - The domain id.
+   * @param {string} options.crn - Full URL-encoded CRN of the service instance.
    * @param {string} options.dataset - The dataset.
-   * @param {string} [options.serviceUrl] - The base url to use when contacting the service. The base url may differ between IBM Cloud regions.
+   * @param {string} options.zoneId - Zone identifier.
+   * @param {string} [options.serviceUrl] - The base URL for the service
    * @param {OutgoingHttpHeaders} [options.headers] - Default headers that shall be included with every request to the service.
    * @param {Authenticator} options.authenticator - The Authenticator object used to authenticate requests to the service
    * @constructor
@@ -96,7 +97,7 @@ class LogpushJobsApiV1 extends BaseService {
   constructor(options: UserOptions) {
     options = options || {};
 
-    const _requiredParams = ['crn','zoneId','dataset'];
+    const _requiredParams = ['crn','dataset','zoneId'];
     const _validationErrors = validateParams(options, _requiredParams, null);
     if (_validationErrors) {
       throw _validationErrors;
@@ -108,8 +109,8 @@ class LogpushJobsApiV1 extends BaseService {
       this.setServiceUrl(LogpushJobsApiV1.DEFAULT_SERVICE_URL);
     }
     this.crn = options.crn;
-    this.zoneId = options.zoneId;
     this.dataset = options.dataset;
+    this.zoneId = options.zoneId;
   }
 
   /*************************
@@ -125,542 +126,12 @@ class LogpushJobsApiV1 extends BaseService {
    * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
    * @returns {Promise<LogpushJobsApiV1.Response<LogpushJobsApiV1.ListLogpushJobsResp>>}
    */
-  public getLogpushJobs(
-    params?: LogpushJobsApiV1.GetLogpushJobsParams
-  ): Promise<LogpushJobsApiV1.Response<LogpushJobsApiV1.ListLogpushJobsResp>> {
-    const _params = { ...params };
-    const _requiredParams = [];
-    const _validParams = ['headers'];
-    const _validationErrors = validateParams(_params, _requiredParams, _validParams);
-    if (_validationErrors) {
-      return Promise.reject(_validationErrors);
-    }
-
-    const path = {
-      'crn': this.crn,
-      'zone_id': this.zoneId,
-    };
-
-    const sdkHeaders = getSdkHeaders(
-      LogpushJobsApiV1.DEFAULT_SERVICE_NAME,
-      'v1',
-      'getLogpushJobs'
-    );
-
-    const parameters = {
-      options: {
-        url: '/v1/{crn}/zones/{zone_id}/logpush/jobs',
-        method: 'GET',
-        path,
-      },
-      defaultOptions: extend(true, {}, this.baseOptions, {
-        headers: extend(
-          true,
-          sdkHeaders,
-          {
-            'Accept': 'application/json',
-          },
-          _params.headers
-        ),
-      }),
-    };
-
-    return this.createRequest(parameters);
-  }
-
-  /**
-   * Create a logpush jobs.
-   *
-   * Create a new logpush job for the domain.
-   *
-   * @param {Object} [params] - The parameters to send to the service.
-   * @param {string} [params.destinationConf] - Uniquely identifies a resource (such as an s3 bucket) where data will be
-   * pushed.
-   * @param {string} [params.ownershipChallenge] - Ownership challenge token to prove destination ownership.
-   * @param {string} [params.name] - Logpush Job Name.
-   * @param {boolean} [params.enabled] - Whether the logpush job enabled or not.
-   * @param {string} [params.logpullOptions] - Configuration string.
-   * @param {string} [params.dataset] - Dataset to be pulled.
-   * @param {string} [params.frequency] - The frequency at which CIS sends batches of logs to your destination.
-   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
-   * @returns {Promise<LogpushJobsApiV1.Response<LogpushJobsApiV1.LogpushJobsResp>>}
-   */
-  public createLogpushJob(
-    params?: LogpushJobsApiV1.CreateLogpushJobParams
-  ): Promise<LogpushJobsApiV1.Response<LogpushJobsApiV1.LogpushJobsResp>> {
-    const _params = { ...params };
-    const _requiredParams = [];
-    const _validParams = ['destinationConf', 'ownershipChallenge', 'name', 'enabled', 'logpullOptions', 'dataset', 'frequency', 'headers'];
-    const _validationErrors = validateParams(_params, _requiredParams, _validParams);
-    if (_validationErrors) {
-      return Promise.reject(_validationErrors);
-    }
-
-    const body = {
-      'destination_conf': _params.destinationConf,
-      'ownership_challenge': _params.ownershipChallenge,
-      'name': _params.name,
-      'enabled': _params.enabled,
-      'logpull_options': _params.logpullOptions,
-      'dataset': _params.dataset,
-      'frequency': _params.frequency,
-    };
-
-    const path = {
-      'crn': this.crn,
-      'zone_id': this.zoneId,
-    };
-
-    const sdkHeaders = getSdkHeaders(
-      LogpushJobsApiV1.DEFAULT_SERVICE_NAME,
-      'v1',
-      'createLogpushJob'
-    );
-
-    const parameters = {
-      options: {
-        url: '/v1/{crn}/zones/{zone_id}/logpush/jobs',
-        method: 'POST',
-        body,
-        path,
-      },
-      defaultOptions: extend(true, {}, this.baseOptions, {
-        headers: extend(
-          true,
-          sdkHeaders,
-          {
-            'Accept': 'application/json',
-            'Content-Type': 'application/json',
-          },
-          _params.headers
-        ),
-      }),
-    };
-
-    return this.createRequest(parameters);
-  }
-
-  /**
-   * Get a logpush job.
-   *
-   * Get a logpush job  for a given zone.
-   *
-   * @param {Object} params - The parameters to send to the service.
-   * @param {number} params.jobId - logpush job identifier.
-   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
-   * @returns {Promise<LogpushJobsApiV1.Response<LogpushJobsApiV1.LogpushJobsResp>>}
-   */
-  public getLogpushJob(
-    params: LogpushJobsApiV1.GetLogpushJobParams
-  ): Promise<LogpushJobsApiV1.Response<LogpushJobsApiV1.LogpushJobsResp>> {
-    const _params = { ...params };
-    const _requiredParams = ['jobId'];
-    const _validParams = ['jobId', 'headers'];
-    const _validationErrors = validateParams(_params, _requiredParams, _validParams);
-    if (_validationErrors) {
-      return Promise.reject(_validationErrors);
-    }
-
-    const path = {
-      'crn': this.crn,
-      'zone_id': this.zoneId,
-      'job_id': _params.jobId,
-    };
-
-    const sdkHeaders = getSdkHeaders(
-      LogpushJobsApiV1.DEFAULT_SERVICE_NAME,
-      'v1',
-      'getLogpushJob'
-    );
-
-    const parameters = {
-      options: {
-        url: '/v1/{crn}/zones/{zone_id}/logpush/jobs/{job_id}',
-        method: 'GET',
-        path,
-      },
-      defaultOptions: extend(true, {}, this.baseOptions, {
-        headers: extend(
-          true,
-          sdkHeaders,
-          {
-            'Accept': 'application/json',
-          },
-          _params.headers
-        ),
-      }),
-    };
-
-    return this.createRequest(parameters);
-  }
-
-  /**
-   * Update a logpush job.
-   *
-   * Update an existing logpush job for a given zone.
-   *
-   * @param {Object} params - The parameters to send to the service.
-   * @param {number} params.jobId - logpush job identifier.
-   * @param {boolean} [params.enabled] - Whether the logpush job enabled or not.
-   * @param {string} [params.logpullOptions] - Configuration string.
-   * @param {string} [params.destinationConf] - Uniquely identifies a resource (such as an s3 bucket) where data will be
-   * pushed.
-   * @param {string} [params.ownershipChallenge] - Ownership challenge token to prove destination ownership.
-   * @param {string} [params.frequency] - The frequency at which CIS sends batches of logs to your destination.
-   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
-   * @returns {Promise<LogpushJobsApiV1.Response<LogpushJobsApiV1.LogpushJobsResp>>}
-   */
-  public updateLogpushJob(
-    params: LogpushJobsApiV1.UpdateLogpushJobParams
-  ): Promise<LogpushJobsApiV1.Response<LogpushJobsApiV1.LogpushJobsResp>> {
-    const _params = { ...params };
-    const _requiredParams = ['jobId'];
-    const _validParams = ['jobId', 'enabled', 'logpullOptions', 'destinationConf', 'ownershipChallenge', 'frequency', 'headers'];
-    const _validationErrors = validateParams(_params, _requiredParams, _validParams);
-    if (_validationErrors) {
-      return Promise.reject(_validationErrors);
-    }
-
-    const body = {
-      'enabled': _params.enabled,
-      'logpull_options': _params.logpullOptions,
-      'destination_conf': _params.destinationConf,
-      'ownership_challenge': _params.ownershipChallenge,
-      'frequency': _params.frequency,
-    };
-
-    const path = {
-      'crn': this.crn,
-      'zone_id': this.zoneId,
-      'job_id': _params.jobId,
-    };
-
-    const sdkHeaders = getSdkHeaders(
-      LogpushJobsApiV1.DEFAULT_SERVICE_NAME,
-      'v1',
-      'updateLogpushJob'
-    );
-
-    const parameters = {
-      options: {
-        url: '/v1/{crn}/zones/{zone_id}/logpush/jobs/{job_id}',
-        method: 'PUT',
-        body,
-        path,
-      },
-      defaultOptions: extend(true, {}, this.baseOptions, {
-        headers: extend(
-          true,
-          sdkHeaders,
-          {
-            'Accept': 'application/json',
-            'Content-Type': 'application/json',
-          },
-          _params.headers
-        ),
-      }),
-    };
-
-    return this.createRequest(parameters);
-  }
-
-  /**
-   * Delete a logpush job.
-   *
-   * Delete a logpush job for a zone.
-   *
-   * @param {Object} params - The parameters to send to the service.
-   * @param {number} params.jobId - logpush job identifier.
-   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
-   * @returns {Promise<LogpushJobsApiV1.Response<LogpushJobsApiV1.DeleteLogpushJobResp>>}
-   */
-  public deleteLogpushJob(
-    params: LogpushJobsApiV1.DeleteLogpushJobParams
-  ): Promise<LogpushJobsApiV1.Response<LogpushJobsApiV1.DeleteLogpushJobResp>> {
-    const _params = { ...params };
-    const _requiredParams = ['jobId'];
-    const _validParams = ['jobId', 'headers'];
-    const _validationErrors = validateParams(_params, _requiredParams, _validParams);
-    if (_validationErrors) {
-      return Promise.reject(_validationErrors);
-    }
-
-    const path = {
-      'crn': this.crn,
-      'zone_id': this.zoneId,
-      'job_id': _params.jobId,
-    };
-
-    const sdkHeaders = getSdkHeaders(
-      LogpushJobsApiV1.DEFAULT_SERVICE_NAME,
-      'v1',
-      'deleteLogpushJob'
-    );
-
-    const parameters = {
-      options: {
-        url: '/v1/{crn}/zones/{zone_id}/logpush/jobs/{job_id}',
-        method: 'DELETE',
-        path,
-      },
-      defaultOptions: extend(true, {}, this.baseOptions, {
-        headers: extend(
-          true,
-          sdkHeaders,
-          {
-            'Accept': 'application/json',
-          },
-          _params.headers
-        ),
-      }),
-    };
-
-    return this.createRequest(parameters);
-  }
-
-  /**
-   * List all fields available for a dataset.
-   *
-   * The list of all fields available for a given dataset.
-   *
-   * @param {Object} [params] - The parameters to send to the service.
-   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
-   * @returns {Promise<LogpushJobsApiV1.Response<LogpushJobsApiV1.ListFieldsResp>>}
-   */
-  public listFieldsForDataset(
-    params?: LogpushJobsApiV1.ListFieldsForDatasetParams
-  ): Promise<LogpushJobsApiV1.Response<LogpushJobsApiV1.ListFieldsResp>> {
-    const _params = { ...params };
-    const _requiredParams = [];
-    const _validParams = ['headers'];
-    const _validationErrors = validateParams(_params, _requiredParams, _validParams);
-    if (_validationErrors) {
-      return Promise.reject(_validationErrors);
-    }
-
-    const path = {
-      'crn': this.crn,
-      'zone_id': this.zoneId,
-      'dataset': this.dataset,
-    };
-
-    const sdkHeaders = getSdkHeaders(
-      LogpushJobsApiV1.DEFAULT_SERVICE_NAME,
-      'v1',
-      'listFieldsForDataset'
-    );
-
-    const parameters = {
-      options: {
-        url: '/v1/{crn}/zones/{zone_id}/logpush/datasets/{dataset}/fields',
-        method: 'GET',
-        path,
-      },
-      defaultOptions: extend(true, {}, this.baseOptions, {
-        headers: extend(
-          true,
-          sdkHeaders,
-          {
-            'Accept': 'application/json',
-          },
-          _params.headers
-        ),
-      }),
-    };
-
-    return this.createRequest(parameters);
-  }
-
-  /**
-   * List logpush jobs for a dataset.
-   *
-   * List configured logpush jobs for a dataset.
-   *
-   * @param {Object} [params] - The parameters to send to the service.
-   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
-   * @returns {Promise<LogpushJobsApiV1.Response<LogpushJobsApiV1.LogpushJobsResp>>}
-   */
-  public listLogpushJobsForDataset(
-    params?: LogpushJobsApiV1.ListLogpushJobsForDatasetParams
-  ): Promise<LogpushJobsApiV1.Response<LogpushJobsApiV1.LogpushJobsResp>> {
-    const _params = { ...params };
-    const _requiredParams = [];
-    const _validParams = ['headers'];
-    const _validationErrors = validateParams(_params, _requiredParams, _validParams);
-    if (_validationErrors) {
-      return Promise.reject(_validationErrors);
-    }
-
-    const path = {
-      'crn': this.crn,
-      'zone_id': this.zoneId,
-      'dataset': this.dataset,
-    };
-
-    const sdkHeaders = getSdkHeaders(
-      LogpushJobsApiV1.DEFAULT_SERVICE_NAME,
-      'v1',
-      'listLogpushJobsForDataset'
-    );
-
-    const parameters = {
-      options: {
-        url: '/v1/{crn}/zones/{zone_id}/logpush/datasets/{dataset}/jobs',
-        method: 'GET',
-        path,
-      },
-      defaultOptions: extend(true, {}, this.baseOptions, {
-        headers: extend(
-          true,
-          sdkHeaders,
-          {
-            'Accept': 'application/json',
-          },
-          _params.headers
-        ),
-      }),
-    };
-
-    return this.createRequest(parameters);
-  }
-
-  /**
-   * Get a new ownership challenge sent to your destination.
-   *
-   * Get a new ownership challenge.
-   *
-   * @param {Object} [params] - The parameters to send to the service.
-   * @param {string} [params.destinationConf] - Uniquely identifies a resource (such as an s3 bucket) where data will be
-   * pushed.
-   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
-   * @returns {Promise<LogpushJobsApiV1.Response<LogpushJobsApiV1.OwnershipChallengeResp>>}
-   */
-  public getLogpushOwnership(
-    params?: LogpushJobsApiV1.GetLogpushOwnershipParams
-  ): Promise<LogpushJobsApiV1.Response<LogpushJobsApiV1.OwnershipChallengeResp>> {
-    const _params = { ...params };
-    const _requiredParams = [];
-    const _validParams = ['destinationConf', 'headers'];
-    const _validationErrors = validateParams(_params, _requiredParams, _validParams);
-    if (_validationErrors) {
-      return Promise.reject(_validationErrors);
-    }
-
-    const body = {
-      'destination_conf': _params.destinationConf,
-    };
-
-    const path = {
-      'crn': this.crn,
-      'zone_id': this.zoneId,
-    };
-
-    const sdkHeaders = getSdkHeaders(
-      LogpushJobsApiV1.DEFAULT_SERVICE_NAME,
-      'v1',
-      'getLogpushOwnership'
-    );
-
-    const parameters = {
-      options: {
-        url: '/v1/{crn}/zones/{zone_id}/logpush/ownership',
-        method: 'POST',
-        body,
-        path,
-      },
-      defaultOptions: extend(true, {}, this.baseOptions, {
-        headers: extend(
-          true,
-          sdkHeaders,
-          {
-            'Accept': 'application/json',
-            'Content-Type': 'application/json',
-          },
-          _params.headers
-        ),
-      }),
-    };
-
-    return this.createRequest(parameters);
-  }
-
-  /**
-   * Validate ownership challenge of the destination.
-   *
-   * Validate ownership challenge of the destination.
-   *
-   * @param {Object} [params] - The parameters to send to the service.
-   * @param {string} [params.destinationConf] - Uniquely identifies a resource (such as an s3 bucket) where data will be
-   * pushed.
-   * @param {string} [params.ownershipChallenge] - Ownership challenge token to prove destination ownership.
-   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
-   * @returns {Promise<LogpushJobsApiV1.Response<LogpushJobsApiV1.OwnershipChallengeValidateResult>>}
-   */
-  public validateLogpushOwnershipChallenge(
-    params?: LogpushJobsApiV1.ValidateLogpushOwnershipChallengeParams
-  ): Promise<LogpushJobsApiV1.Response<LogpushJobsApiV1.OwnershipChallengeValidateResult>> {
-    const _params = { ...params };
-    const _requiredParams = [];
-    const _validParams = ['destinationConf', 'ownershipChallenge', 'headers'];
-    const _validationErrors = validateParams(_params, _requiredParams, _validParams);
-    if (_validationErrors) {
-      return Promise.reject(_validationErrors);
-    }
-
-    const body = {
-      'destination_conf': _params.destinationConf,
-      'ownership_challenge': _params.ownershipChallenge,
-    };
-
-    const path = {
-      'crn': this.crn,
-      'zone_id': this.zoneId,
-    };
-
-    const sdkHeaders = getSdkHeaders(
-      LogpushJobsApiV1.DEFAULT_SERVICE_NAME,
-      'v1',
-      'validateLogpushOwnershipChallenge'
-    );
-
-    const parameters = {
-      options: {
-        url: '/v1/{crn}/zones/{zone_id}/logpush/ownership/validate',
-        method: 'POST',
-        body,
-        path,
-      },
-      defaultOptions: extend(true, {}, this.baseOptions, {
-        headers: extend(
-          true,
-          sdkHeaders,
-          {
-            'Accept': 'application/json',
-            'Content-Type': 'application/json',
-          },
-          _params.headers
-        ),
-      }),
-    };
-
-    return this.createRequest(parameters);
-  }
-
-  /**
-   * List logpush jobs.
-   *
-   * List configured logpush jobs for your domain.
-   *
-   * @param {Object} [params] - The parameters to send to the service.
-   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
-   * @returns {Promise<LogpushJobsApiV1.Response<LogpushJobsApiV1.ListLogpushJobsResp>>}
-   */
   public getLogpushJobsV2(
     params?: LogpushJobsApiV1.GetLogpushJobsV2Params
   ): Promise<LogpushJobsApiV1.Response<LogpushJobsApiV1.ListLogpushJobsResp>> {
     const _params = { ...params };
     const _requiredParams = [];
-    const _validParams = ['headers'];
+    const _validParams = ['signal', 'headers'];
     const _validationErrors = validateParams(_params, _requiredParams, _validParams);
     if (_validationErrors) {
       return Promise.reject(_validationErrors);
@@ -671,11 +142,7 @@ class LogpushJobsApiV1 extends BaseService {
       'zone_id': this.zoneId,
     };
 
-    const sdkHeaders = getSdkHeaders(
-      LogpushJobsApiV1.DEFAULT_SERVICE_NAME,
-      'v1',
-      'getLogpushJobsV2'
-    );
+    const sdkHeaders = getSdkHeaders(LogpushJobsApiV1.DEFAULT_SERVICE_NAME, 'v1', 'getLogpushJobsV2');
 
     const parameters = {
       options: {
@@ -687,11 +154,15 @@ class LogpushJobsApiV1 extends BaseService {
         headers: extend(
           true,
           sdkHeaders,
+          this.baseOptions.headers,
           {
             'Accept': 'application/json',
           },
           _params.headers
         ),
+        axiosOptions: {
+          signal: _params.signal,
+        },
       }),
     };
 
@@ -713,7 +184,7 @@ class LogpushJobsApiV1 extends BaseService {
   ): Promise<LogpushJobsApiV1.Response<LogpushJobsApiV1.LogpushJobsResp>> {
     const _params = { ...params };
     const _requiredParams = [];
-    const _validParams = ['createLogpushJobV2Request', 'headers'];
+    const _validParams = ['createLogpushJobV2Request', 'signal', 'headers'];
     const _validationErrors = validateParams(_params, _requiredParams, _validParams);
     if (_validationErrors) {
       return Promise.reject(_validationErrors);
@@ -725,11 +196,7 @@ class LogpushJobsApiV1 extends BaseService {
       'zone_id': this.zoneId,
     };
 
-    const sdkHeaders = getSdkHeaders(
-      LogpushJobsApiV1.DEFAULT_SERVICE_NAME,
-      'v1',
-      'createLogpushJobV2'
-    );
+    const sdkHeaders = getSdkHeaders(LogpushJobsApiV1.DEFAULT_SERVICE_NAME, 'v1', 'createLogpushJobV2');
 
     const parameters = {
       options: {
@@ -742,12 +209,16 @@ class LogpushJobsApiV1 extends BaseService {
         headers: extend(
           true,
           sdkHeaders,
+          this.baseOptions.headers,
           {
             'Accept': 'application/json',
             'Content-Type': 'application/json',
           },
           _params.headers
         ),
+        axiosOptions: {
+          signal: _params.signal,
+        },
       }),
     };
 
@@ -760,7 +231,7 @@ class LogpushJobsApiV1 extends BaseService {
    * Get a logpush job  for a given zone.
    *
    * @param {Object} params - The parameters to send to the service.
-   * @param {number} params.jobId - logpush job identifier.
+   * @param {string} params.jobId - logpush job identifier.
    * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
    * @returns {Promise<LogpushJobsApiV1.Response<LogpushJobsApiV1.LogpushJobsResp>>}
    */
@@ -769,7 +240,7 @@ class LogpushJobsApiV1 extends BaseService {
   ): Promise<LogpushJobsApiV1.Response<LogpushJobsApiV1.LogpushJobsResp>> {
     const _params = { ...params };
     const _requiredParams = ['jobId'];
-    const _validParams = ['jobId', 'headers'];
+    const _validParams = ['jobId', 'signal', 'headers'];
     const _validationErrors = validateParams(_params, _requiredParams, _validParams);
     if (_validationErrors) {
       return Promise.reject(_validationErrors);
@@ -781,11 +252,7 @@ class LogpushJobsApiV1 extends BaseService {
       'job_id': _params.jobId,
     };
 
-    const sdkHeaders = getSdkHeaders(
-      LogpushJobsApiV1.DEFAULT_SERVICE_NAME,
-      'v1',
-      'getLogpushJobV2'
-    );
+    const sdkHeaders = getSdkHeaders(LogpushJobsApiV1.DEFAULT_SERVICE_NAME, 'v1', 'getLogpushJobV2');
 
     const parameters = {
       options: {
@@ -797,11 +264,15 @@ class LogpushJobsApiV1 extends BaseService {
         headers: extend(
           true,
           sdkHeaders,
+          this.baseOptions.headers,
           {
             'Accept': 'application/json',
           },
           _params.headers
         ),
+        axiosOptions: {
+          signal: _params.signal,
+        },
       }),
     };
 
@@ -814,7 +285,7 @@ class LogpushJobsApiV1 extends BaseService {
    * Update an existing logpush job for a given zone.
    *
    * @param {Object} params - The parameters to send to the service.
-   * @param {number} params.jobId - logpush job identifier.
+   * @param {string} params.jobId - logpush job identifier.
    * @param {UpdateLogpushJobV2Request} [params.updateLogpushJobV2Request] - Update logpush job.
    * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
    * @returns {Promise<LogpushJobsApiV1.Response<LogpushJobsApiV1.LogpushJobsResp>>}
@@ -824,7 +295,7 @@ class LogpushJobsApiV1 extends BaseService {
   ): Promise<LogpushJobsApiV1.Response<LogpushJobsApiV1.LogpushJobsResp>> {
     const _params = { ...params };
     const _requiredParams = ['jobId'];
-    const _validParams = ['jobId', 'updateLogpushJobV2Request', 'headers'];
+    const _validParams = ['jobId', 'updateLogpushJobV2Request', 'signal', 'headers'];
     const _validationErrors = validateParams(_params, _requiredParams, _validParams);
     if (_validationErrors) {
       return Promise.reject(_validationErrors);
@@ -837,11 +308,7 @@ class LogpushJobsApiV1 extends BaseService {
       'job_id': _params.jobId,
     };
 
-    const sdkHeaders = getSdkHeaders(
-      LogpushJobsApiV1.DEFAULT_SERVICE_NAME,
-      'v1',
-      'updateLogpushJobV2'
-    );
+    const sdkHeaders = getSdkHeaders(LogpushJobsApiV1.DEFAULT_SERVICE_NAME, 'v1', 'updateLogpushJobV2');
 
     const parameters = {
       options: {
@@ -854,12 +321,16 @@ class LogpushJobsApiV1 extends BaseService {
         headers: extend(
           true,
           sdkHeaders,
+          this.baseOptions.headers,
           {
             'Accept': 'application/json',
             'Content-Type': 'application/json',
           },
           _params.headers
         ),
+        axiosOptions: {
+          signal: _params.signal,
+        },
       }),
     };
 
@@ -872,7 +343,7 @@ class LogpushJobsApiV1 extends BaseService {
    * Delete a logpush job for a zone.
    *
    * @param {Object} params - The parameters to send to the service.
-   * @param {number} params.jobId - logpush job identifier.
+   * @param {string} params.jobId - logpush job identifier.
    * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
    * @returns {Promise<LogpushJobsApiV1.Response<LogpushJobsApiV1.DeleteLogpushJobResp>>}
    */
@@ -881,7 +352,7 @@ class LogpushJobsApiV1 extends BaseService {
   ): Promise<LogpushJobsApiV1.Response<LogpushJobsApiV1.DeleteLogpushJobResp>> {
     const _params = { ...params };
     const _requiredParams = ['jobId'];
-    const _validParams = ['jobId', 'headers'];
+    const _validParams = ['jobId', 'signal', 'headers'];
     const _validationErrors = validateParams(_params, _requiredParams, _validParams);
     if (_validationErrors) {
       return Promise.reject(_validationErrors);
@@ -893,11 +364,7 @@ class LogpushJobsApiV1 extends BaseService {
       'job_id': _params.jobId,
     };
 
-    const sdkHeaders = getSdkHeaders(
-      LogpushJobsApiV1.DEFAULT_SERVICE_NAME,
-      'v1',
-      'deleteLogpushJobV2'
-    );
+    const sdkHeaders = getSdkHeaders(LogpushJobsApiV1.DEFAULT_SERVICE_NAME, 'v1', 'deleteLogpushJobV2');
 
     const parameters = {
       options: {
@@ -909,11 +376,15 @@ class LogpushJobsApiV1 extends BaseService {
         headers: extend(
           true,
           sdkHeaders,
+          this.baseOptions.headers,
           {
             'Accept': 'application/json',
           },
           _params.headers
         ),
+        axiosOptions: {
+          signal: _params.signal,
+        },
       }),
     };
 
@@ -935,7 +406,7 @@ class LogpushJobsApiV1 extends BaseService {
   ): Promise<LogpushJobsApiV1.Response<LogpushJobsApiV1.OwnershipChallengeResp>> {
     const _params = { ...params };
     const _requiredParams = [];
-    const _validParams = ['cos', 'headers'];
+    const _validParams = ['cos', 'signal', 'headers'];
     const _validationErrors = validateParams(_params, _requiredParams, _validParams);
     if (_validationErrors) {
       return Promise.reject(_validationErrors);
@@ -950,11 +421,7 @@ class LogpushJobsApiV1 extends BaseService {
       'zone_id': this.zoneId,
     };
 
-    const sdkHeaders = getSdkHeaders(
-      LogpushJobsApiV1.DEFAULT_SERVICE_NAME,
-      'v1',
-      'getLogpushOwnershipV2'
-    );
+    const sdkHeaders = getSdkHeaders(LogpushJobsApiV1.DEFAULT_SERVICE_NAME, 'v1', 'getLogpushOwnershipV2');
 
     const parameters = {
       options: {
@@ -967,12 +434,16 @@ class LogpushJobsApiV1 extends BaseService {
         headers: extend(
           true,
           sdkHeaders,
+          this.baseOptions.headers,
           {
             'Accept': 'application/json',
             'Content-Type': 'application/json',
           },
           _params.headers
         ),
+        axiosOptions: {
+          signal: _params.signal,
+        },
       }),
     };
 
@@ -995,7 +466,7 @@ class LogpushJobsApiV1 extends BaseService {
   ): Promise<LogpushJobsApiV1.Response<LogpushJobsApiV1.OwnershipChallengeValidateResult>> {
     const _params = { ...params };
     const _requiredParams = [];
-    const _validParams = ['cos', 'ownershipChallenge', 'headers'];
+    const _validParams = ['cos', 'ownershipChallenge', 'signal', 'headers'];
     const _validationErrors = validateParams(_params, _requiredParams, _validParams);
     if (_validationErrors) {
       return Promise.reject(_validationErrors);
@@ -1011,11 +482,7 @@ class LogpushJobsApiV1 extends BaseService {
       'zone_id': this.zoneId,
     };
 
-    const sdkHeaders = getSdkHeaders(
-      LogpushJobsApiV1.DEFAULT_SERVICE_NAME,
-      'v1',
-      'validateLogpushOwnershipChallengeV2'
-    );
+    const sdkHeaders = getSdkHeaders(LogpushJobsApiV1.DEFAULT_SERVICE_NAME, 'v1', 'validateLogpushOwnershipChallengeV2');
 
     const parameters = {
       options: {
@@ -1028,12 +495,16 @@ class LogpushJobsApiV1 extends BaseService {
         headers: extend(
           true,
           sdkHeaders,
+          this.baseOptions.headers,
           {
             'Accept': 'application/json',
             'Content-Type': 'application/json',
           },
           _params.headers
         ),
+        axiosOptions: {
+          signal: _params.signal,
+        },
       }),
     };
 
@@ -1054,7 +525,7 @@ class LogpushJobsApiV1 extends BaseService {
   ): Promise<LogpushJobsApiV1.Response<LogpushJobsApiV1.ListFieldsResp>> {
     const _params = { ...params };
     const _requiredParams = [];
-    const _validParams = ['headers'];
+    const _validParams = ['signal', 'headers'];
     const _validationErrors = validateParams(_params, _requiredParams, _validParams);
     if (_validationErrors) {
       return Promise.reject(_validationErrors);
@@ -1066,11 +537,7 @@ class LogpushJobsApiV1 extends BaseService {
       'dataset': this.dataset,
     };
 
-    const sdkHeaders = getSdkHeaders(
-      LogpushJobsApiV1.DEFAULT_SERVICE_NAME,
-      'v1',
-      'listFieldsForDatasetV2'
-    );
+    const sdkHeaders = getSdkHeaders(LogpushJobsApiV1.DEFAULT_SERVICE_NAME, 'v1', 'listFieldsForDatasetV2');
 
     const parameters = {
       options: {
@@ -1082,11 +549,15 @@ class LogpushJobsApiV1 extends BaseService {
         headers: extend(
           true,
           sdkHeaders,
+          this.baseOptions.headers,
           {
             'Accept': 'application/json',
           },
           _params.headers
         ),
+        axiosOptions: {
+          signal: _params.signal,
+        },
       }),
     };
 
@@ -1107,7 +578,7 @@ class LogpushJobsApiV1 extends BaseService {
   ): Promise<LogpushJobsApiV1.Response<LogpushJobsApiV1.LogpushJobsResp>> {
     const _params = { ...params };
     const _requiredParams = [];
-    const _validParams = ['headers'];
+    const _validParams = ['signal', 'headers'];
     const _validationErrors = validateParams(_params, _requiredParams, _validParams);
     if (_validationErrors) {
       return Promise.reject(_validationErrors);
@@ -1119,11 +590,7 @@ class LogpushJobsApiV1 extends BaseService {
       'dataset': this.dataset,
     };
 
-    const sdkHeaders = getSdkHeaders(
-      LogpushJobsApiV1.DEFAULT_SERVICE_NAME,
-      'v1',
-      'listLogpushJobsForDatasetV2'
-    );
+    const sdkHeaders = getSdkHeaders(LogpushJobsApiV1.DEFAULT_SERVICE_NAME, 'v1', 'listLogpushJobsForDatasetV2');
 
     const parameters = {
       options: {
@@ -1135,11 +602,126 @@ class LogpushJobsApiV1 extends BaseService {
         headers: extend(
           true,
           sdkHeaders,
+          this.baseOptions.headers,
           {
             'Accept': 'application/json',
           },
           _params.headers
         ),
+        axiosOptions: {
+          signal: _params.signal,
+        },
+      }),
+    };
+
+    return this.createRequest(parameters);
+  }
+
+  /**
+   * Get log retention.
+   *
+   * Get log retention setting for Logpull/Logpush on your domain.
+   *
+   * @param {Object} [params] - The parameters to send to the service.
+   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
+   * @returns {Promise<LogpushJobsApiV1.Response<LogpushJobsApiV1.LogRetentionResp>>}
+   */
+  public getLogsRetention(
+    params?: LogpushJobsApiV1.GetLogsRetentionParams
+  ): Promise<LogpushJobsApiV1.Response<LogpushJobsApiV1.LogRetentionResp>> {
+    const _params = { ...params };
+    const _requiredParams = [];
+    const _validParams = ['signal', 'headers'];
+    const _validationErrors = validateParams(_params, _requiredParams, _validParams);
+    if (_validationErrors) {
+      return Promise.reject(_validationErrors);
+    }
+
+    const path = {
+      'crn': this.crn,
+      'zone_id': this.zoneId,
+    };
+
+    const sdkHeaders = getSdkHeaders(LogpushJobsApiV1.DEFAULT_SERVICE_NAME, 'v1', 'getLogsRetention');
+
+    const parameters = {
+      options: {
+        url: '/v1/{crn}/zones/{zone_id}/logs/retention',
+        method: 'GET',
+        path,
+      },
+      defaultOptions: extend(true, {}, this.baseOptions, {
+        headers: extend(
+          true,
+          sdkHeaders,
+          this.baseOptions.headers,
+          {
+            'Accept': 'application/json',
+          },
+          _params.headers
+        ),
+        axiosOptions: {
+          signal: _params.signal,
+        },
+      }),
+    };
+
+    return this.createRequest(parameters);
+  }
+
+  /**
+   * Update log retention.
+   *
+   * Update log retention flag for Logpull/Logpush.
+   *
+   * @param {Object} [params] - The parameters to send to the service.
+   * @param {boolean} [params.flag] -
+   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
+   * @returns {Promise<LogpushJobsApiV1.Response<LogpushJobsApiV1.LogRetentionResp>>}
+   */
+  public createLogRetention(
+    params?: LogpushJobsApiV1.CreateLogRetentionParams
+  ): Promise<LogpushJobsApiV1.Response<LogpushJobsApiV1.LogRetentionResp>> {
+    const _params = { ...params };
+    const _requiredParams = [];
+    const _validParams = ['flag', 'signal', 'headers'];
+    const _validationErrors = validateParams(_params, _requiredParams, _validParams);
+    if (_validationErrors) {
+      return Promise.reject(_validationErrors);
+    }
+
+    const body = {
+      'flag': _params.flag,
+    };
+
+    const path = {
+      'crn': this.crn,
+      'zone_id': this.zoneId,
+    };
+
+    const sdkHeaders = getSdkHeaders(LogpushJobsApiV1.DEFAULT_SERVICE_NAME, 'v1', 'createLogRetention');
+
+    const parameters = {
+      options: {
+        url: '/v1/{crn}/zones/{zone_id}/logs/retention',
+        method: 'POST',
+        body,
+        path,
+      },
+      defaultOptions: extend(true, {}, this.baseOptions, {
+        headers: extend(
+          true,
+          sdkHeaders,
+          this.baseOptions.headers,
+          {
+            'Accept': 'application/json',
+            'Content-Type': 'application/json',
+          },
+          _params.headers
+        ),
+        axiosOptions: {
+          signal: _params.signal,
+        },
       }),
     };
 
@@ -1154,12 +736,12 @@ class LogpushJobsApiV1 extends BaseService {
 namespace LogpushJobsApiV1 {
   /** Options for the `LogpushJobsApiV1` constructor. */
   export interface Options extends UserOptions {
-    /** Full url-encoded CRN of the service instance. */
+    /** Full URL-encoded CRN of the service instance. */
     crn: string;
-    /** The domain id. */
-    zoneId: string;
     /** The dataset. */
     dataset: string;
+    /** Zone identifier. */
+    zoneId: string;
   }
 
   /** An operation response. */
@@ -1174,7 +756,7 @@ namespace LogpushJobsApiV1 {
   export type Callback<T> = (error: any, response?: Response<T>) => void;
 
   /** The body of a service request that returns no response data. */
-  export interface Empty {}
+  export interface EmptyObject {}
 
   /** A standard JS object, defined to avoid the limitations of `Object` and `object` */
   export interface JsonObject {
@@ -1185,195 +767,124 @@ namespace LogpushJobsApiV1 {
    * request interfaces
    ************************/
 
-  /** Parameters for the `getLogpushJobs` operation. */
-  export interface GetLogpushJobsParams {
-    headers?: OutgoingHttpHeaders;
-  }
-
-  /** Parameters for the `createLogpushJob` operation. */
-  export interface CreateLogpushJobParams {
-    /** Uniquely identifies a resource (such as an s3 bucket) where data will be pushed. */
-    destinationConf?: string;
-    /** Ownership challenge token to prove destination ownership. */
-    ownershipChallenge?: string;
-    /** Logpush Job Name. */
-    name?: string;
-    /** Whether the logpush job enabled or not. */
-    enabled?: boolean;
-    /** Configuration string. */
-    logpullOptions?: string;
-    /** Dataset to be pulled. */
-    dataset?: CreateLogpushJobConstants.Dataset | string;
-    /** The frequency at which CIS sends batches of logs to your destination. */
-    frequency?: CreateLogpushJobConstants.Frequency | string;
-    headers?: OutgoingHttpHeaders;
-  }
-
-  /** Constants for the `createLogpushJob` operation. */
-  export namespace CreateLogpushJobConstants {
-    /** Dataset to be pulled. */
-    export enum Dataset {
-      HTTP_REQUESTS = 'http_requests',
-      RANGE_EVENTS = 'range_events',
-      FIREWALL_EVENTS = 'firewall_events',
-    }
-    /** The frequency at which CIS sends batches of logs to your destination. */
-    export enum Frequency {
-      HIGH = 'high',
-      LOW = 'low',
-    }
-  }
-
-  /** Parameters for the `getLogpushJob` operation. */
-  export interface GetLogpushJobParams {
-    /** logpush job identifier. */
-    jobId: number;
-    headers?: OutgoingHttpHeaders;
-  }
-
-  /** Parameters for the `updateLogpushJob` operation. */
-  export interface UpdateLogpushJobParams {
-    /** logpush job identifier. */
-    jobId: number;
-    /** Whether the logpush job enabled or not. */
-    enabled?: boolean;
-    /** Configuration string. */
-    logpullOptions?: string;
-    /** Uniquely identifies a resource (such as an s3 bucket) where data will be pushed. */
-    destinationConf?: string;
-    /** Ownership challenge token to prove destination ownership. */
-    ownershipChallenge?: string;
-    /** The frequency at which CIS sends batches of logs to your destination. */
-    frequency?: UpdateLogpushJobConstants.Frequency | string;
-    headers?: OutgoingHttpHeaders;
-  }
-
-  /** Constants for the `updateLogpushJob` operation. */
-  export namespace UpdateLogpushJobConstants {
-    /** The frequency at which CIS sends batches of logs to your destination. */
-    export enum Frequency {
-      HIGH = 'high',
-      LOW = 'low',
-    }
-  }
-
-  /** Parameters for the `deleteLogpushJob` operation. */
-  export interface DeleteLogpushJobParams {
-    /** logpush job identifier. */
-    jobId: number;
-    headers?: OutgoingHttpHeaders;
-  }
-
-  /** Parameters for the `listFieldsForDataset` operation. */
-  export interface ListFieldsForDatasetParams {
-    headers?: OutgoingHttpHeaders;
-  }
-
-  /** Constants for the `listFieldsForDataset` operation. */
-  export namespace ListFieldsForDatasetConstants {
-  }
-
-  /** Parameters for the `listLogpushJobsForDataset` operation. */
-  export interface ListLogpushJobsForDatasetParams {
-    headers?: OutgoingHttpHeaders;
-  }
-
-  /** Constants for the `listLogpushJobsForDataset` operation. */
-  export namespace ListLogpushJobsForDatasetConstants {
-  }
-
-  /** Parameters for the `getLogpushOwnership` operation. */
-  export interface GetLogpushOwnershipParams {
-    /** Uniquely identifies a resource (such as an s3 bucket) where data will be pushed. */
-    destinationConf?: string;
-    headers?: OutgoingHttpHeaders;
-  }
-
-  /** Parameters for the `validateLogpushOwnershipChallenge` operation. */
-  export interface ValidateLogpushOwnershipChallengeParams {
-    /** Uniquely identifies a resource (such as an s3 bucket) where data will be pushed. */
-    destinationConf?: string;
-    /** Ownership challenge token to prove destination ownership. */
-    ownershipChallenge?: string;
-    headers?: OutgoingHttpHeaders;
-  }
+   interface DefaultParams {
+     headers?: OutgoingHttpHeaders;
+     signal?: AbortSignal;
+   }
 
   /** Parameters for the `getLogpushJobsV2` operation. */
-  export interface GetLogpushJobsV2Params {
-    headers?: OutgoingHttpHeaders;
+  export interface GetLogpushJobsV2Params extends DefaultParams {
   }
 
   /** Parameters for the `createLogpushJobV2` operation. */
-  export interface CreateLogpushJobV2Params {
+  export interface CreateLogpushJobV2Params extends DefaultParams {
     /** Create logpush job body. */
     createLogpushJobV2Request?: CreateLogpushJobV2Request;
-    headers?: OutgoingHttpHeaders;
   }
 
   /** Parameters for the `getLogpushJobV2` operation. */
-  export interface GetLogpushJobV2Params {
+  export interface GetLogpushJobV2Params extends DefaultParams {
     /** logpush job identifier. */
-    jobId: number;
-    headers?: OutgoingHttpHeaders;
+    jobId: string;
   }
 
   /** Parameters for the `updateLogpushJobV2` operation. */
-  export interface UpdateLogpushJobV2Params {
+  export interface UpdateLogpushJobV2Params extends DefaultParams {
     /** logpush job identifier. */
-    jobId: number;
+    jobId: string;
     /** Update logpush job. */
     updateLogpushJobV2Request?: UpdateLogpushJobV2Request;
-    headers?: OutgoingHttpHeaders;
   }
 
   /** Parameters for the `deleteLogpushJobV2` operation. */
-  export interface DeleteLogpushJobV2Params {
+  export interface DeleteLogpushJobV2Params extends DefaultParams {
     /** logpush job identifier. */
-    jobId: number;
-    headers?: OutgoingHttpHeaders;
+    jobId: string;
   }
 
   /** Parameters for the `getLogpushOwnershipV2` operation. */
-  export interface GetLogpushOwnershipV2Params {
+  export interface GetLogpushOwnershipV2Params extends DefaultParams {
     /** Information to identify the COS bucket where the data will be pushed. */
     cos?: JsonObject;
-    headers?: OutgoingHttpHeaders;
   }
 
   /** Parameters for the `validateLogpushOwnershipChallengeV2` operation. */
-  export interface ValidateLogpushOwnershipChallengeV2Params {
+  export interface ValidateLogpushOwnershipChallengeV2Params extends DefaultParams {
     /** Information to identify the COS bucket where the data will be pushed. */
     cos?: JsonObject;
     /** Ownership challenge token to prove destination ownership. */
     ownershipChallenge?: string;
-    headers?: OutgoingHttpHeaders;
   }
 
   /** Parameters for the `listFieldsForDatasetV2` operation. */
-  export interface ListFieldsForDatasetV2Params {
-    headers?: OutgoingHttpHeaders;
+  export interface ListFieldsForDatasetV2Params extends DefaultParams {
   }
 
   /** Parameters for the `listLogpushJobsForDatasetV2` operation. */
-  export interface ListLogpushJobsForDatasetV2Params {
-    headers?: OutgoingHttpHeaders;
+  export interface ListLogpushJobsForDatasetV2Params extends DefaultParams {
+  }
+
+  /** Parameters for the `getLogsRetention` operation. */
+  export interface GetLogsRetentionParams extends DefaultParams {
+  }
+
+  /** Parameters for the `createLogRetention` operation. */
+  export interface CreateLogRetentionParams extends DefaultParams {
+    flag?: boolean;
   }
 
   /*************************
    * model interfaces
    ************************/
 
-  /** CreateLogpushJobV2Request. */
+  /**
+   * CreateLogpushJobV2Request.
+   */
   export interface CreateLogpushJobV2Request {
   }
 
-  /** UpdateLogpushJobV2Request. */
+  /**
+   * LogRetentionRespResult.
+   */
+  export interface LogRetentionRespResult {
+    flag?: boolean;
+  }
+
+  /**
+   * Required information to push logs to your Cloud Logs instance.
+   */
+  export interface LogpushJobIbmclReqIbmcl {
+    /** GUID of the IBM Cloud Logs instance where you want to send logs. */
+    instance_id: string;
+    /** Region where the IBM Cloud Logs instance is located. */
+    region: string;
+    /** IBM Cloud API key used to generate a token for pushing to your Cloud Logs instance. */
+    api_key: string;
+  }
+
+  /**
+   * Required information to push logs to your Cloud Logs instance.
+   */
+  export interface LogpushJobsUpdateIbmclReqIbmcl {
+    /** GUID of the IBM Cloud Logs instance where you want to send logs. */
+    instance_id?: string;
+    /** Region where the IBM Cloud Logs instance is located. */
+    region?: string;
+    /** IBM Cloud API key used to generate a token for pushing to your Cloud Logs instance. */
+    api_key?: string;
+  }
+
+  /**
+   * UpdateLogpushJobV2Request.
+   */
   export interface UpdateLogpushJobV2Request {
   }
 
-  /** delete logpush job response. */
+  /**
+   * delete logpush job response.
+   */
   export interface DeleteLogpushJobResp {
-    /** success respose. */
+    /** success response. */
     success: boolean;
     /** errors. */
     errors: string[][];
@@ -1383,7 +894,9 @@ namespace LogpushJobsApiV1 {
     result: JsonObject;
   }
 
-  /** list fields response. */
+  /**
+   * list fields response.
+   */
   export interface ListFieldsResp {
     /** success response. */
     success: boolean;
@@ -1395,7 +908,9 @@ namespace LogpushJobsApiV1 {
     result?: JsonObject;
   }
 
-  /** List Logpush Jobs Response. */
+  /**
+   * List Logpush Jobs Response.
+   */
   export interface ListLogpushJobsResp {
     /** success response. */
     success: boolean;
@@ -1407,7 +922,22 @@ namespace LogpushJobsApiV1 {
     result: LogpushJobPack[];
   }
 
-  /** logpush job pack. */
+  /**
+   * log retention result.
+   */
+  export interface LogRetentionResp {
+    result?: LogRetentionRespResult;
+    /** success response. */
+    success?: boolean;
+    /** errors. */
+    errors?: string[][];
+    /** messages. */
+    messages?: string[][];
+  }
+
+  /**
+   * logpush job pack.
+   */
   export interface LogpushJobPack {
     /** Logpush Job ID. */
     id: number;
@@ -1424,14 +954,16 @@ namespace LogpushJobsApiV1 {
     /** Uniquely identifies a resource (such as an s3 bucket) where data will be pushed. */
     destination_conf: string;
     /** Records the last time for which logs have been successfully pushed. */
-    last_complete: string;
+    last_complete?: string;
     /** Records the last time the job failed. */
-    last_error: string;
+    last_error?: string;
     /** The last failure. */
-    error_message: string;
+    error_message?: string;
   }
 
-  /** logpush job response. */
+  /**
+   * logpush job response.
+   */
   export interface LogpushJobsResp {
     /** success response. */
     success: boolean;
@@ -1443,7 +975,9 @@ namespace LogpushJobsApiV1 {
     result: LogpushJobPack;
   }
 
-  /** Get Logpush Ownership Challenge Response. */
+  /**
+   * Get Logpush Ownership Challenge Response.
+   */
   export interface OwnershipChallengeResp {
     /** success response. */
     success: boolean;
@@ -1455,7 +989,9 @@ namespace LogpushJobsApiV1 {
     result: OwnershipChallengeResult;
   }
 
-  /** ownership challenge result. */
+  /**
+   * ownership challenge result.
+   */
   export interface OwnershipChallengeResult {
     /** file name. */
     filename: string;
@@ -1465,13 +1001,17 @@ namespace LogpushJobsApiV1 {
     messages?: string;
   }
 
-  /** ownership challenge validate result. */
+  /**
+   * ownership challenge validate result.
+   */
   export interface OwnershipChallengeValidateResult {
     /** valid. */
     valid: boolean;
   }
 
-  /** Create COS logpush job input. */
+  /**
+   * Create COS logpush job input.
+   */
   export interface CreateLogpushJobV2RequestLogpushJobCosReq extends CreateLogpushJobV2Request {
     /** Logpush Job Name. */
     name?: string;
@@ -1484,12 +1024,97 @@ namespace LogpushJobsApiV1 {
     /** Ownership challenge token to prove destination ownership. */
     ownership_challenge: string;
     /** Dataset to be pulled. */
-    dataset?: string;
+    dataset?: CreateLogpushJobV2RequestLogpushJobCosReq.Constants.Dataset | string;
     /** The frequency at which CIS sends batches of logs to your destination. */
-    frequency?: string;
+    frequency?: CreateLogpushJobV2RequestLogpushJobCosReq.Constants.Frequency | string;
+  }
+  export namespace CreateLogpushJobV2RequestLogpushJobCosReq {
+    export namespace Constants {
+      /** Dataset to be pulled. */
+      export enum Dataset {
+        HTTP_REQUESTS = 'http_requests',
+        RANGE_EVENTS = 'range_events',
+        FIREWALL_EVENTS = 'firewall_events',
+      }
+      /** The frequency at which CIS sends batches of logs to your destination. */
+      export enum Frequency {
+        HIGH = 'high',
+        LOW = 'low',
+      }
+    }
   }
 
-  /** Create LogDNA logpush job input. */
+  /**
+   * Create logpush job for a generic destination.
+   */
+  export interface CreateLogpushJobV2RequestLogpushJobGenericReq extends CreateLogpushJobV2Request {
+    /** Logpush Job Name. */
+    name?: string;
+    /** Whether the logpush job is enabled or not. */
+    enabled?: boolean;
+    /** Configuration string. */
+    logpull_options?: string;
+    /** Uniquely identifies a resource where data will be pushed. Additional configuration parameters supported by
+     *  the destination may be included.
+     */
+    destination_conf: string;
+    /** Dataset to be pulled. */
+    dataset?: CreateLogpushJobV2RequestLogpushJobGenericReq.Constants.Dataset | string;
+    /** The frequency at which CIS sends batches of logs to your destination. */
+    frequency?: CreateLogpushJobV2RequestLogpushJobGenericReq.Constants.Frequency | string;
+  }
+  export namespace CreateLogpushJobV2RequestLogpushJobGenericReq {
+    export namespace Constants {
+      /** Dataset to be pulled. */
+      export enum Dataset {
+        HTTP_REQUESTS = 'http_requests',
+        RANGE_EVENTS = 'range_events',
+        FIREWALL_EVENTS = 'firewall_events',
+      }
+      /** The frequency at which CIS sends batches of logs to your destination. */
+      export enum Frequency {
+        HIGH = 'high',
+        LOW = 'low',
+      }
+    }
+  }
+
+  /**
+   * Create IBM Cloud Logs logpush job input.
+   */
+  export interface CreateLogpushJobV2RequestLogpushJobIbmclReq extends CreateLogpushJobV2Request {
+    /** Logpush Job Name. */
+    name?: string;
+    /** Whether the logpush job is enabled or not. */
+    enabled?: boolean;
+    /** Configuration string. */
+    logpull_options?: string;
+    /** Required information to push logs to your Cloud Logs instance. */
+    ibmcl: LogpushJobIbmclReqIbmcl;
+    /** Dataset to be pulled. */
+    dataset?: CreateLogpushJobV2RequestLogpushJobIbmclReq.Constants.Dataset | string;
+    /** The frequency at which CIS sends batches of logs to your destination. */
+    frequency?: CreateLogpushJobV2RequestLogpushJobIbmclReq.Constants.Frequency | string;
+  }
+  export namespace CreateLogpushJobV2RequestLogpushJobIbmclReq {
+    export namespace Constants {
+      /** Dataset to be pulled. */
+      export enum Dataset {
+        HTTP_REQUESTS = 'http_requests',
+        RANGE_EVENTS = 'range_events',
+        FIREWALL_EVENTS = 'firewall_events',
+      }
+      /** The frequency at which CIS sends batches of logs to your destination. */
+      export enum Frequency {
+        HIGH = 'high',
+        LOW = 'low',
+      }
+    }
+  }
+
+  /**
+   * Create LogDNA logpush job input.
+   */
   export interface CreateLogpushJobV2RequestLogpushJobLogdnaReq extends CreateLogpushJobV2Request {
     /** Logpush Job Name. */
     name?: string;
@@ -1500,12 +1125,29 @@ namespace LogpushJobsApiV1 {
     /** Information to identify the LogDNA instance the data will be pushed. */
     logdna: JsonObject;
     /** Dataset to be pulled. */
-    dataset?: string;
+    dataset?: CreateLogpushJobV2RequestLogpushJobLogdnaReq.Constants.Dataset | string;
     /** The frequency at which CIS sends batches of logs to your destination. */
-    frequency?: string;
+    frequency?: CreateLogpushJobV2RequestLogpushJobLogdnaReq.Constants.Frequency | string;
+  }
+  export namespace CreateLogpushJobV2RequestLogpushJobLogdnaReq {
+    export namespace Constants {
+      /** Dataset to be pulled. */
+      export enum Dataset {
+        HTTP_REQUESTS = 'http_requests',
+        RANGE_EVENTS = 'range_events',
+        FIREWALL_EVENTS = 'firewall_events',
+      }
+      /** The frequency at which CIS sends batches of logs to your destination. */
+      export enum Frequency {
+        HIGH = 'high',
+        LOW = 'low',
+      }
+    }
   }
 
-  /** Update COS logpush job input. */
+  /**
+   * Update COS logpush job input.
+   */
   export interface UpdateLogpushJobV2RequestLogpushJobsUpdateCosReq extends UpdateLogpushJobV2Request {
     /** Whether the logpush job enabled or not. */
     enabled?: boolean;
@@ -1516,10 +1158,79 @@ namespace LogpushJobsApiV1 {
     /** Ownership challenge token to prove destination ownership. */
     ownership_challenge?: string;
     /** The frequency at which CIS sends batches of logs to your destination. */
-    frequency?: string;
+    frequency?: UpdateLogpushJobV2RequestLogpushJobsUpdateCosReq.Constants.Frequency | string;
+  }
+  export namespace UpdateLogpushJobV2RequestLogpushJobsUpdateCosReq {
+    export namespace Constants {
+      /** The frequency at which CIS sends batches of logs to your destination. */
+      export enum Frequency {
+        HIGH = 'high',
+        LOW = 'low',
+      }
+    }
   }
 
-  /** Update LogDNA logpush job input. */
+  /**
+   * Create logpush job for a generic destination.
+   */
+  export interface UpdateLogpushJobV2RequestLogpushJobsUpdateGenericReq extends UpdateLogpushJobV2Request {
+    /** Logpush Job Name. */
+    name?: string;
+    /** Whether the logpush job is enabled or not. */
+    enabled?: boolean;
+    /** Configuration string. */
+    logpull_options?: string;
+    /** Uniquely identifies a resource where data will be pushed. Additional configuration parameters supported by
+     *  the destination may be included.
+     */
+    destination_conf?: string;
+    /** Dataset to be pulled. */
+    dataset?: UpdateLogpushJobV2RequestLogpushJobsUpdateGenericReq.Constants.Dataset | string;
+    /** The frequency at which CIS sends batches of logs to your destination. */
+    frequency?: UpdateLogpushJobV2RequestLogpushJobsUpdateGenericReq.Constants.Frequency | string;
+  }
+  export namespace UpdateLogpushJobV2RequestLogpushJobsUpdateGenericReq {
+    export namespace Constants {
+      /** Dataset to be pulled. */
+      export enum Dataset {
+        HTTP_REQUESTS = 'http_requests',
+        RANGE_EVENTS = 'range_events',
+        FIREWALL_EVENTS = 'firewall_events',
+      }
+      /** The frequency at which CIS sends batches of logs to your destination. */
+      export enum Frequency {
+        HIGH = 'high',
+        LOW = 'low',
+      }
+    }
+  }
+
+  /**
+   * Update IBM Cloud Logs logpush job input.
+   */
+  export interface UpdateLogpushJobV2RequestLogpushJobsUpdateIbmclReq extends UpdateLogpushJobV2Request {
+    /** Whether the logpush job enabled or not. */
+    enabled?: boolean;
+    /** Configuration string. */
+    logpull_options?: string;
+    /** Required information to push logs to your Cloud Logs instance. */
+    ibmcl?: LogpushJobsUpdateIbmclReqIbmcl;
+    /** The frequency at which CIS sends batches of logs to your destination. */
+    frequency?: UpdateLogpushJobV2RequestLogpushJobsUpdateIbmclReq.Constants.Frequency | string;
+  }
+  export namespace UpdateLogpushJobV2RequestLogpushJobsUpdateIbmclReq {
+    export namespace Constants {
+      /** The frequency at which CIS sends batches of logs to your destination. */
+      export enum Frequency {
+        HIGH = 'high',
+        LOW = 'low',
+      }
+    }
+  }
+
+  /**
+   * Update LogDNA logpush job input.
+   */
   export interface UpdateLogpushJobV2RequestLogpushJobsUpdateLogdnaReq extends UpdateLogpushJobV2Request {
     /** Whether the logpush job enabled or not. */
     enabled?: boolean;
@@ -1528,7 +1239,16 @@ namespace LogpushJobsApiV1 {
     /** Information to identify the LogDNA instance the data will be pushed. */
     logdna?: JsonObject;
     /** The frequency at which CIS sends batches of logs to your destination. */
-    frequency?: string;
+    frequency?: UpdateLogpushJobV2RequestLogpushJobsUpdateLogdnaReq.Constants.Frequency | string;
+  }
+  export namespace UpdateLogpushJobV2RequestLogpushJobsUpdateLogdnaReq {
+    export namespace Constants {
+      /** The frequency at which CIS sends batches of logs to your destination. */
+      export enum Frequency {
+        HIGH = 'high',
+        LOW = 'low',
+      }
+    }
   }
 }
 

--- a/test/integration/cis/logpush-jobs-api.v1.test.js
+++ b/test/integration/cis/logpush-jobs-api.v1.test.js
@@ -146,6 +146,301 @@ describe('LogPushJobsApiV1', () => {
         done(err);
       }
     });
+
+  describe('Create/Update/Delete LogPushJobs for Generic destination (S3)', () => {
+    test('should successfully create/update/delete LogPushJobs for generic destination', async done => {
+      try {
+        // Skip if not configured
+        if (!config.GENERIC_DESTINATION_CONF) {
+          console.log('Skipping generic destination test - not configured');
+          return done();
+        }
+
+        const name = 'TestGeneric';
+        const enabled = false;
+        const logpull_options = 'timestamps=rfc3339&timestamps=rfc3339';
+        const destination_conf = config.GENERIC_DESTINATION_CONF || 's3://mybucket/logs?region=us-west-2';
+        const dataset = 'http_requests';
+        const frequency = 'high';
+
+        const createLogpushJobV2RequestModel = {
+          name: name,
+          enabled: enabled,
+          logpull_options: logpull_options,
+          destination_conf: destination_conf,
+          dataset: dataset,
+          frequency: frequency,
+        };
+
+        const params = {
+          createLogpushJobV2Request: createLogpushJobV2RequestModel,
+        };
+
+        const response = await logpushV1.createLogpushJobV2(params);
+        expect(response).toBeDefined();
+        expect(response.status).toEqual(201);
+
+        const { result } = response || {};
+        expect(result).toBeDefined();
+        expect(result.result).toBeDefined();
+
+        const jobId = result.result.id;
+        expect(jobId).toBeDefined();
+
+        // Update the job
+        const updateLogpushJobV2RequestModel = {
+          enabled: false,
+          logpull_options: 'timestamps=rfc3339',
+          destination_conf: destination_conf,
+          frequency: 'low',
+        };
+
+        const updateParams = {
+          jobId: jobId,
+          updateLogpushJobV2Request: updateLogpushJobV2RequestModel,
+        };
+
+        const updateResponse = await logpushV1.updateLogpushJobV2(updateParams);
+        expect(updateResponse).toBeDefined();
+        expect(updateResponse.status).toEqual(200);
+
+        // Delete the job
+        const deleteParams = {
+          jobId: jobId,
+        };
+
+        const deleteResponse = await logpushV1.deleteLogpushJobV2(deleteParams);
+        expect(deleteResponse).toBeDefined();
+        expect(deleteResponse.status).toEqual(200);
+
+        done();
+      } catch (err) {
+        done(err);
+      }
+    });
+  });
+
+  describe('Create/Update/Delete LogPushJobs for Custom HTTP destination', () => {
+    test('should successfully create/update/delete LogPushJobs for HTTP destination', async done => {
+      try {
+        const name = 'TestHTTP';
+        const enabled = false;
+        const logpull_options = 'fields=ClientIP,ClientRequestHost,ClientRequestMethod';
+        const destination_conf = 'https://httpbin.org/post';
+        const dataset = 'http_requests';
+        const frequency = 'high';
+
+        const createLogpushJobV2RequestModel = {
+          name: name,
+          enabled: enabled,
+          logpull_options: logpull_options,
+          destination_conf: destination_conf,
+          dataset: dataset,
+          frequency: frequency,
+        };
+
+        const params = {
+          createLogpushJobV2Request: createLogpushJobV2RequestModel,
+        };
+
+        const response = await logpushV1.createLogpushJobV2(params);
+        expect(response).toBeDefined();
+        expect(response.status).toEqual(201);
+
+        const { result } = response || {};
+        expect(result).toBeDefined();
+        expect(result.result).toBeDefined();
+
+        const jobId = result.result.id;
+        expect(jobId).toBeDefined();
+
+        // Update the job
+        const updateLogpushJobV2RequestModel = {
+          enabled: false,
+          logpull_options: 'fields=ClientIP,ClientRequestHost',
+          destination_conf: destination_conf,
+          frequency: 'high',
+        };
+
+        const updateParams = {
+          jobId: jobId,
+          updateLogpushJobV2Request: updateLogpushJobV2RequestModel,
+        };
+
+        const updateResponse = await logpushV1.updateLogpushJobV2(updateParams);
+        expect(updateResponse).toBeDefined();
+        expect(updateResponse.status).toEqual(200);
+
+        // Delete the job
+        const deleteParams = {
+          jobId: jobId,
+        };
+
+        const deleteResponse = await logpushV1.deleteLogpushJobV2(deleteParams);
+        expect(deleteResponse).toBeDefined();
+        expect(deleteResponse.status).toEqual(200);
+
+        done();
+      } catch (err) {
+        done(err);
+      }
+    });
+  });
+
+  describe('Create/Update/Delete LogPushJobs for COS destination', () => {
+    test('should successfully create/update/delete LogPushJobs for COS', async done => {
+      try {
+        // Skip if COS credentials not available
+        if (!config.COS_BUCKET || !config.COS_REGION || !config.COS_INSTANCE || !config.OWNERSHIP_TOKEN) {
+          console.log('Skipping COS destination test - credentials not configured');
+          return done();
+        }
+
+        const name = 'TestCOS';
+        const enabled = false;
+        const logpull_options = 'timestamps=rfc3339&timestamps=rfc3339';
+        const cos = {
+          bucket_name: config.COS_BUCKET,
+          region: config.COS_REGION,
+          id: config.COS_INSTANCE,
+        };
+        const dataset = 'http_requests';
+        const frequency = 'high';
+        const ownership_challenge = config.OWNERSHIP_TOKEN;
+
+        const createLogpushJobV2RequestModel = {
+          name: name,
+          enabled: enabled,
+          logpull_options: logpull_options,
+          cos: cos,
+          dataset: dataset,
+          frequency: frequency,
+          ownership_challenge: ownership_challenge,
+        };
+
+        const params = {
+          createLogpushJobV2Request: createLogpushJobV2RequestModel,
+        };
+
+        const response = await logpushV1.createLogpushJobV2(params);
+        expect(response).toBeDefined();
+        expect(response.status).toEqual(201);
+
+        const { result } = response || {};
+        expect(result).toBeDefined();
+        expect(result.result).toBeDefined();
+
+        const jobId = result.result.id;
+        expect(jobId).toBeDefined();
+
+        // Update the job
+        const updateLogpushJobV2RequestModel = {
+          enabled: false,
+          logpull_options: 'timestamps=rfc3339',
+          frequency: 'low',
+        };
+
+        const updateParams = {
+          jobId: jobId,
+          updateLogpushJobV2Request: updateLogpushJobV2RequestModel,
+        };
+
+        const updateResponse = await logpushV1.updateLogpushJobV2(updateParams);
+        expect(updateResponse).toBeDefined();
+        expect(updateResponse.status).toEqual(200);
+
+        // Delete the job
+        const deleteParams = {
+          jobId: jobId,
+        };
+
+        const deleteResponse = await logpushV1.deleteLogpushJobV2(deleteParams);
+        expect(deleteResponse).toBeDefined();
+        expect(deleteResponse.status).toEqual(200);
+
+        done();
+      } catch (err) {
+        done(err);
+      }
+    });
+  });
+
+  describe('Create/Update/Delete LogPushJobs for IBMCL destination', () => {
+    test('should successfully create/update/delete LogPushJobs for IBMCL', async done => {
+      try {
+        // Skip if IBMCL credentials not available
+        if (!config.IBMCL_INSTANCE_ID) {
+          console.log('Skipping IBMCL destination test - credentials not configured');
+          return done();
+        }
+
+        const name = 'TestIBMCL';
+        const enabled = false;
+        const logpull_options = 'timestamps=rfc3339&timestamps=rfc3339';
+        const ibmcl = {
+          instance_id: config.IBMCL_INSTANCE_ID,
+          region: 'us-south',
+          api_key: config.CIS_SERVICES_APIKEY,
+        };
+        const dataset = 'http_requests';
+        const frequency = 'high';
+
+        const createLogpushJobV2RequestModel = {
+          name: name,
+          enabled: enabled,
+          logpull_options: logpull_options,
+          ibmcl: ibmcl,
+          dataset: dataset,
+          frequency: frequency,
+        };
+
+        const params = {
+          createLogpushJobV2Request: createLogpushJobV2RequestModel,
+        };
+
+        const response = await logpushV1.createLogpushJobV2(params);
+        expect(response).toBeDefined();
+        expect(response.status).toEqual(201);
+
+        const { result } = response || {};
+        expect(result).toBeDefined();
+        expect(result.result).toBeDefined();
+
+        const jobId = result.result.id;
+        expect(jobId).toBeDefined();
+
+        // Update the job
+        const updateLogpushJobV2RequestModel = {
+          enabled: false,
+          logpull_options: 'timestamps=rfc3339',
+          frequency: 'low',
+        };
+
+        const updateParams = {
+          jobId: jobId,
+          updateLogpushJobV2Request: updateLogpushJobV2RequestModel,
+        };
+
+        const updateResponse = await logpushV1.updateLogpushJobV2(updateParams);
+        expect(updateResponse).toBeDefined();
+        expect(updateResponse.status).toEqual(200);
+
+        // Delete the job
+        const deleteParams = {
+          jobId: jobId,
+        };
+
+        const deleteResponse = await logpushV1.deleteLogpushJobV2(deleteParams);
+        expect(deleteResponse).toBeDefined();
+        expect(deleteResponse.status).toEqual(200);
+
+        done();
+      } catch (err) {
+        done(err);
+      }
+    });
+  });
+
   });
 
   describe('List the LogPushJobs LogDNA', () => {
@@ -240,6 +535,125 @@ describe('LogPushJobsApiV1', () => {
         done(err);
       }
     });
+
+  describe('List fields for dataset', () => {
+    test('should successfully list fields for dataset', async done => {
+      try {
+        const response = await logpushV1.listFieldsForDatasetV2();
+        expect(response).toBeDefined();
+        expect(response.status).toEqual(200);
+
+        const { result } = response || {};
+
+        expect(result).toBeDefined();
+        if (result && result.result) {
+          expect(result.result).toBeDefined();
+          expect(result.success).toBeTruthy();
+        }
+        done();
+      } catch (err) {
+        done(err);
+      }
+    });
+  });
+
+  describe('List logpush jobs for dataset', () => {
+    test('should successfully list logpush jobs for dataset', async done => {
+      try {
+        const response = await logpushV1.listLogpushJobsForDatasetV2();
+        expect(response).toBeDefined();
+        expect(response.status).toEqual(200);
+
+        const { result } = response || {};
+
+        expect(result).toBeDefined();
+        if (result && result.result) {
+          expect(result.result).toBeDefined();
+        }
+        done();
+      } catch (err) {
+        done(err);
+      }
+    });
+  });
+
+  describe('Get and validate logpush ownership challenge', () => {
+    test('should successfully get ownership challenge', async done => {
+      try {
+        // Skip if COS credentials not available
+        if (!config.COS_BUCKET || !config.COS_REGION || !config.COS_INSTANCE) {
+          console.log('Skipping ownership test - COS credentials not configured');
+          return done();
+        }
+
+        const cos = {
+          bucket_name: config.COS_BUCKET,
+          region: config.COS_REGION,
+          id: config.COS_INSTANCE,
+        };
+
+        const params = {
+          cos: cos,
+        };
+
+        const response = await logpushV1.getLogpushOwnershipV2(params);
+        expect(response).toBeDefined();
+        expect(response.status).toEqual(200);
+
+        const { result } = response || {};
+        expect(result).toBeDefined();
+
+        if (result && result.result) {
+          expect(result.result).toBeDefined();
+          expect(result.success).toBeTruthy();
+        }
+        done();
+      } catch (err) {
+        done(err);
+      }
+    });
+
+    test('should successfully validate ownership challenge', async done => {
+      try {
+        // Skip if COS credentials or ownership token not available
+        if (
+          !config.COS_BUCKET ||
+          !config.COS_REGION ||
+          !config.COS_INSTANCE ||
+          !config.OWNERSHIP_TOKEN
+        ) {
+          console.log('Skipping validation test - COS credentials or token not configured');
+          return done();
+        }
+
+        const cos = {
+          bucket_name: config.COS_BUCKET,
+          region: config.COS_REGION,
+          id: config.COS_INSTANCE,
+        };
+
+        const params = {
+          cos: cos,
+          ownershipChallenge: config.OWNERSHIP_TOKEN,
+        };
+
+        const response = await logpushV1.validateLogpushOwnershipChallengeV2(params);
+        expect(response).toBeDefined();
+        expect(response.status).toEqual(200);
+
+        const { result } = response || {};
+        expect(result).toBeDefined();
+
+        if (result && result.result) {
+          expect(result.result).toBeDefined();
+        }
+        done();
+      } catch (err) {
+        done(err);
+      }
+    });
+  });
+
   });
 
   describe('delete the Webhooks by ID', () => {

--- a/test/integration/cis/logpush-jobs-api.v1.test.js
+++ b/test/integration/cis/logpush-jobs-api.v1.test.js
@@ -58,6 +58,11 @@ describe('LogPushJobsApiV1', () => {
 
   let logpushIdentifier;
 
+  beforeAll(() => {
+    // Initialize the service client before all tests
+    logpushV1 = LogPushJobsApiV1.newInstance(options);
+  });
+
   test('should successfully complete initialization', done => {
     // Initialize the service client .
     logpushV1 = LogPushJobsApiV1.newInstance(options);
@@ -221,69 +226,63 @@ describe('LogPushJobsApiV1', () => {
   });
 
   describe('Create/Update/Delete LogPushJobs for Custom HTTP destination', () => {
-    test('should successfully create/update/delete LogPushJobs for HTTP destination', async done => {
-      try {
-        const name = 'TestHTTP';
-        const enabled = false;
-        const logpull_options = 'fields=ClientIP,ClientRequestHost,ClientRequestMethod';
-        const destination_conf = 'https://httpbin.org/post';
-        const dataset = 'http_requests';
-        const frequency = 'high';
+    test('should successfully create/update/delete LogPushJobs for HTTP destination', async () => {
+      const name = 'TestHTTP';
+      const enabled = false;
+      const logpull_options = 'fields=ClientIP,ClientRequestHost,ClientRequestMethod';
+      const destination_conf = 'https://httpbin.org/post';
+      const dataset = 'http_requests';
+      const frequency = 'high';
 
-        const createLogpushJobV2RequestModel = {
-          name: name,
-          enabled: enabled,
-          logpull_options: logpull_options,
-          destination_conf: destination_conf,
-          dataset: dataset,
-          frequency: frequency,
-        };
+      const createLogpushJobV2RequestModel = {
+        name: name,
+        enabled: enabled,
+        logpull_options: logpull_options,
+        destination_conf: destination_conf,
+        dataset: dataset,
+        frequency: frequency,
+      };
 
-        const params = {
-          createLogpushJobV2Request: createLogpushJobV2RequestModel,
-        };
+      const params = {
+        createLogpushJobV2Request: createLogpushJobV2RequestModel,
+      };
 
-        const response = await logpushV1.createLogpushJobV2(params);
-        expect(response).toBeDefined();
-        expect(response.status).toEqual(201);
+      const response = await logpushV1.createLogpushJobV2(params);
+      expect(response).toBeDefined();
+      expect(response.status).toEqual(201);
 
-        const { result } = response || {};
-        expect(result).toBeDefined();
-        expect(result.result).toBeDefined();
+      const { result } = response || {};
+      expect(result).toBeDefined();
+      expect(result.result).toBeDefined();
 
-        const jobId = result.result.id;
-        expect(jobId).toBeDefined();
+      const jobId = result.result.id;
+      expect(jobId).toBeDefined();
 
-        // Update the job
-        const updateLogpushJobV2RequestModel = {
-          enabled: false,
-          logpull_options: 'fields=ClientIP,ClientRequestHost',
-          destination_conf: destination_conf,
-          frequency: 'high',
-        };
+      // Update the job
+      const updateLogpushJobV2RequestModel = {
+        enabled: false,
+        logpull_options: 'fields=ClientIP,ClientRequestHost',
+        destination_conf: destination_conf,
+        frequency: 'high',
+      };
 
-        const updateParams = {
-          jobId: jobId,
-          updateLogpushJobV2Request: updateLogpushJobV2RequestModel,
-        };
+      const updateParams = {
+        jobId: jobId,
+        updateLogpushJobV2Request: updateLogpushJobV2RequestModel,
+      };
 
-        const updateResponse = await logpushV1.updateLogpushJobV2(updateParams);
-        expect(updateResponse).toBeDefined();
-        expect(updateResponse.status).toEqual(200);
+      const updateResponse = await logpushV1.updateLogpushJobV2(updateParams);
+      expect(updateResponse).toBeDefined();
+      expect(updateResponse.status).toEqual(200);
 
-        // Delete the job
-        const deleteParams = {
-          jobId: jobId,
-        };
+      // Delete the job
+      const deleteParams = {
+        jobId: jobId,
+      };
 
-        const deleteResponse = await logpushV1.deleteLogpushJobV2(deleteParams);
-        expect(deleteResponse).toBeDefined();
-        expect(deleteResponse.status).toEqual(200);
-
-        done();
-      } catch (err) {
-        done(err);
-      }
+      const deleteResponse = await logpushV1.deleteLogpushJobV2(deleteParams);
+      expect(deleteResponse).toBeDefined();
+      expect(deleteResponse.status).toEqual(200);
     });
   });
 

--- a/test/unit/cis/logpush-jobs-api.v1.test.js
+++ b/test/unit/cis/logpush-jobs-api.v1.test.js
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corp. 2022.
+ * (C) Copyright IBM Corp. 2026.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,9 +15,9 @@
  */
 
 // need to import the whole package to mock getAuthenticatorFromEnvironment
-const core = require('ibm-cloud-sdk-core');
-const { NoAuthAuthenticator, unitTestUtils } = core;
+const sdkCorePackage = require('ibm-cloud-sdk-core');
 
+const { NoAuthAuthenticator } = sdkCorePackage;
 const LogpushJobsApiV1 = require('../../../dist/cis/logpushjobsapiv1/v1');
 
 const {
@@ -32,37 +32,45 @@ const logpushJobsApiServiceOptions = {
   authenticator: new NoAuthAuthenticator(),
   url: 'https://api.cis.cloud.ibm.com',
   crn: 'testString',
-  zoneId: 'testString',
   dataset: 'testString',
+  zoneId: 'testString',
 };
 
 const logpushJobsApiService = new LogpushJobsApiV1(logpushJobsApiServiceOptions);
 
-// dont actually create a request
-const createRequestMock = jest.spyOn(logpushJobsApiService, 'createRequest');
-createRequestMock.mockImplementation(() => Promise.resolve());
+let createRequestMock = null;
+function mock_createRequest() {
+  if (!createRequestMock) {
+    createRequestMock = jest.spyOn(logpushJobsApiService, 'createRequest');
+    createRequestMock.mockImplementation(() => Promise.resolve());
+  }
+}
 
 // dont actually construct an authenticator
-const getAuthenticatorMock = jest.spyOn(core, 'getAuthenticatorFromEnvironment');
+const getAuthenticatorMock = jest.spyOn(sdkCorePackage, 'getAuthenticatorFromEnvironment');
 getAuthenticatorMock.mockImplementation(() => new NoAuthAuthenticator());
-
-afterEach(() => {
-  createRequestMock.mockClear();
-  getAuthenticatorMock.mockClear();
-});
 
 // used for the service construction tests
 let requiredGlobals;
-beforeEach(() => {
-  // these are changed when passed into the factory/constructor, so re-init
-  requiredGlobals = {
-    crn: 'testString',
-    zoneId: 'testString',
-    dataset: 'testString',
-  };
-});
 
 describe('LogpushJobsApiV1', () => {
+  beforeEach(() => {
+    mock_createRequest();
+    // these are changed when passed into the factory/constructor, so re-init
+    requiredGlobals = {
+      crn: 'testString',
+      dataset: 'testString',
+      zoneId: 'testString',
+    };
+  });
+
+  afterEach(() => {
+    if (createRequestMock) {
+      createRequestMock.mockClear();
+    }
+    getAuthenticatorMock.mockClear();
+  });
+
   describe('the newInstance method', () => {
     test('should use defaults when options not provided', () => {
       const testInstance = LogpushJobsApiV1.newInstance(requiredGlobals);
@@ -92,6 +100,7 @@ describe('LogpushJobsApiV1', () => {
       expect(testInstance).toBeInstanceOf(LogpushJobsApiV1);
     });
   });
+
   describe('the constructor', () => {
     test('use user-given service url', () => {
       let options = {
@@ -118,745 +127,26 @@ describe('LogpushJobsApiV1', () => {
       expect(testInstance.baseOptions.serviceUrl).toBe(LogpushJobsApiV1.DEFAULT_SERVICE_URL);
     });
   });
+
   describe('service-level tests', () => {
     describe('positive tests', () => {
       test('construct service with global params', () => {
         const serviceObj = new LogpushJobsApiV1(logpushJobsApiServiceOptions);
         expect(serviceObj).not.toBeNull();
         expect(serviceObj.crn).toEqual(logpushJobsApiServiceOptions.crn);
-        expect(serviceObj.zoneId).toEqual(logpushJobsApiServiceOptions.zoneId);
         expect(serviceObj.dataset).toEqual(logpushJobsApiServiceOptions.dataset);
+        expect(serviceObj.zoneId).toEqual(logpushJobsApiServiceOptions.zoneId);
       });
     });
   });
-  describe('getLogpushJobs', () => {
-    describe('positive tests', () => {
-      function __getLogpushJobsTest() {
-        // Construct the params object for operation getLogpushJobs
-        const getLogpushJobsParams = {};
 
-        const getLogpushJobsResult = logpushJobsApiService.getLogpushJobs(getLogpushJobsParams);
-
-        // all methods should return a Promise
-        expectToBePromise(getLogpushJobsResult);
-
-        // assert that create request was called
-        expect(createRequestMock).toHaveBeenCalledTimes(1);
-
-        const mockRequestOptions = getOptions(createRequestMock);
-
-        checkUrlAndMethod(mockRequestOptions, '/v1/{crn}/zones/{zone_id}/logpush/jobs', 'GET');
-        const expectedAccept = 'application/json';
-        const expectedContentType = undefined;
-        checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
-        expect(mockRequestOptions.path.crn).toEqual(logpushJobsApiServiceOptions.crn);
-        expect(mockRequestOptions.path.zone_id).toEqual(logpushJobsApiServiceOptions.zoneId);
-      }
-
-      test('should pass the right params to createRequest with enable and disable retries', () => {
-        // baseline test
-        __getLogpushJobsTest();
-
-        // enable retries and test again
-        createRequestMock.mockClear();
-        logpushJobsApiService.enableRetries();
-        __getLogpushJobsTest();
-
-        // disable retries and test again
-        createRequestMock.mockClear();
-        logpushJobsApiService.disableRetries();
-        __getLogpushJobsTest();
-      });
-
-      test('should prioritize user-given headers', () => {
-        // parameters
-        const userAccept = 'fake/accept';
-        const userContentType = 'fake/contentType';
-        const getLogpushJobsParams = {
-          headers: {
-            Accept: userAccept,
-            'Content-Type': userContentType,
-          },
-        };
-
-        logpushJobsApiService.getLogpushJobs(getLogpushJobsParams);
-        checkMediaHeaders(createRequestMock, userAccept, userContentType);
-      });
-
-      test('should not have any problems when no parameters are passed in', () => {
-        // invoke the method with no parameters
-        logpushJobsApiService.getLogpushJobs({});
-        checkForSuccessfulExecution(createRequestMock);
-      });
-    });
-  });
-  describe('createLogpushJob', () => {
-    describe('positive tests', () => {
-      function __createLogpushJobTest() {
-        // Construct the params object for operation createLogpushJob
-        const destinationConf =
-          'cos://cos-bucket001?region=us-south&instance-id=231f5467-3072-4cb9-9e39-a906fa3032ea';
-        const ownershipChallenge = '00000000000000000000000000000000';
-        const name = 'My log push job';
-        const enabled = false;
-        const logpullOptions = 'timestamps=rfc3339&timestamps=rfc3339';
-        const dataset = 'firewall_events';
-        const frequency = 'high';
-        const createLogpushJobParams = {
-          destinationConf: destinationConf,
-          ownershipChallenge: ownershipChallenge,
-          name: name,
-          enabled: enabled,
-          logpullOptions: logpullOptions,
-          dataset: dataset,
-          frequency: frequency,
-        };
-
-        const createLogpushJobResult = logpushJobsApiService.createLogpushJob(
-          createLogpushJobParams
-        );
-
-        // all methods should return a Promise
-        expectToBePromise(createLogpushJobResult);
-
-        // assert that create request was called
-        expect(createRequestMock).toHaveBeenCalledTimes(1);
-
-        const mockRequestOptions = getOptions(createRequestMock);
-
-        checkUrlAndMethod(mockRequestOptions, '/v1/{crn}/zones/{zone_id}/logpush/jobs', 'POST');
-        const expectedAccept = 'application/json';
-        const expectedContentType = 'application/json';
-        checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
-        expect(mockRequestOptions.body.destination_conf).toEqual(destinationConf);
-        expect(mockRequestOptions.body.ownership_challenge).toEqual(ownershipChallenge);
-        expect(mockRequestOptions.body.name).toEqual(name);
-        expect(mockRequestOptions.body.enabled).toEqual(enabled);
-        expect(mockRequestOptions.body.logpull_options).toEqual(logpullOptions);
-        expect(mockRequestOptions.body.dataset).toEqual(dataset);
-        expect(mockRequestOptions.body.frequency).toEqual(frequency);
-        expect(mockRequestOptions.path.crn).toEqual(logpushJobsApiServiceOptions.crn);
-        expect(mockRequestOptions.path.zone_id).toEqual(logpushJobsApiServiceOptions.zoneId);
-      }
-
-      test('should pass the right params to createRequest with enable and disable retries', () => {
-        // baseline test
-        __createLogpushJobTest();
-
-        // enable retries and test again
-        createRequestMock.mockClear();
-        logpushJobsApiService.enableRetries();
-        __createLogpushJobTest();
-
-        // disable retries and test again
-        createRequestMock.mockClear();
-        logpushJobsApiService.disableRetries();
-        __createLogpushJobTest();
-      });
-
-      test('should prioritize user-given headers', () => {
-        // parameters
-        const userAccept = 'fake/accept';
-        const userContentType = 'fake/contentType';
-        const createLogpushJobParams = {
-          headers: {
-            Accept: userAccept,
-            'Content-Type': userContentType,
-          },
-        };
-
-        logpushJobsApiService.createLogpushJob(createLogpushJobParams);
-        checkMediaHeaders(createRequestMock, userAccept, userContentType);
-      });
-
-      test('should not have any problems when no parameters are passed in', () => {
-        // invoke the method with no parameters
-        logpushJobsApiService.createLogpushJob({});
-        checkForSuccessfulExecution(createRequestMock);
-      });
-    });
-  });
-  describe('getLogpushJob', () => {
-    describe('positive tests', () => {
-      function __getLogpushJobTest() {
-        // Construct the params object for operation getLogpushJob
-        const jobId = 38;
-        const getLogpushJobParams = {
-          jobId: jobId,
-        };
-
-        const getLogpushJobResult = logpushJobsApiService.getLogpushJob(getLogpushJobParams);
-
-        // all methods should return a Promise
-        expectToBePromise(getLogpushJobResult);
-
-        // assert that create request was called
-        expect(createRequestMock).toHaveBeenCalledTimes(1);
-
-        const mockRequestOptions = getOptions(createRequestMock);
-
-        checkUrlAndMethod(
-          mockRequestOptions,
-          '/v1/{crn}/zones/{zone_id}/logpush/jobs/{job_id}',
-          'GET'
-        );
-        const expectedAccept = 'application/json';
-        const expectedContentType = undefined;
-        checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
-        expect(mockRequestOptions.path.crn).toEqual(logpushJobsApiServiceOptions.crn);
-        expect(mockRequestOptions.path.zone_id).toEqual(logpushJobsApiServiceOptions.zoneId);
-        expect(mockRequestOptions.path.job_id).toEqual(jobId);
-      }
-
-      test('should pass the right params to createRequest with enable and disable retries', () => {
-        // baseline test
-        __getLogpushJobTest();
-
-        // enable retries and test again
-        createRequestMock.mockClear();
-        logpushJobsApiService.enableRetries();
-        __getLogpushJobTest();
-
-        // disable retries and test again
-        createRequestMock.mockClear();
-        logpushJobsApiService.disableRetries();
-        __getLogpushJobTest();
-      });
-
-      test('should prioritize user-given headers', () => {
-        // parameters
-        const jobId = 38;
-        const userAccept = 'fake/accept';
-        const userContentType = 'fake/contentType';
-        const getLogpushJobParams = {
-          jobId,
-          headers: {
-            Accept: userAccept,
-            'Content-Type': userContentType,
-          },
-        };
-
-        logpushJobsApiService.getLogpushJob(getLogpushJobParams);
-        checkMediaHeaders(createRequestMock, userAccept, userContentType);
-      });
-    });
-
-    describe('negative tests', () => {
-      test('should enforce required parameters', async () => {
-        let err;
-        try {
-          await logpushJobsApiService.getLogpushJob({});
-        } catch (e) {
-          err = e;
-        }
-
-        expect(err.message).toMatch(/Missing required parameters/);
-      });
-
-      test('should reject promise when required params are not given', async () => {
-        let err;
-        try {
-          await logpushJobsApiService.getLogpushJob();
-        } catch (e) {
-          err = e;
-        }
-
-        expect(err.message).toMatch(/Missing required parameters/);
-      });
-    });
-  });
-  describe('updateLogpushJob', () => {
-    describe('positive tests', () => {
-      function __updateLogpushJobTest() {
-        // Construct the params object for operation updateLogpushJob
-        const jobId = 38;
-        const enabled = false;
-        const logpullOptions = 'timestamps=rfc3339&timestamps=rfc3339';
-        const destinationConf =
-          'cos://cos-bucket001?region=us-south&instance-id=231f5467-3072-4cb9-9e39-a906fa3032ea';
-        const ownershipChallenge = '00000000000000000000000000000000';
-        const frequency = 'high';
-        const updateLogpushJobParams = {
-          jobId: jobId,
-          enabled: enabled,
-          logpullOptions: logpullOptions,
-          destinationConf: destinationConf,
-          ownershipChallenge: ownershipChallenge,
-          frequency: frequency,
-        };
-
-        const updateLogpushJobResult = logpushJobsApiService.updateLogpushJob(
-          updateLogpushJobParams
-        );
-
-        // all methods should return a Promise
-        expectToBePromise(updateLogpushJobResult);
-
-        // assert that create request was called
-        expect(createRequestMock).toHaveBeenCalledTimes(1);
-
-        const mockRequestOptions = getOptions(createRequestMock);
-
-        checkUrlAndMethod(
-          mockRequestOptions,
-          '/v1/{crn}/zones/{zone_id}/logpush/jobs/{job_id}',
-          'PUT'
-        );
-        const expectedAccept = 'application/json';
-        const expectedContentType = 'application/json';
-        checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
-        expect(mockRequestOptions.body.enabled).toEqual(enabled);
-        expect(mockRequestOptions.body.logpull_options).toEqual(logpullOptions);
-        expect(mockRequestOptions.body.destination_conf).toEqual(destinationConf);
-        expect(mockRequestOptions.body.ownership_challenge).toEqual(ownershipChallenge);
-        expect(mockRequestOptions.body.frequency).toEqual(frequency);
-        expect(mockRequestOptions.path.crn).toEqual(logpushJobsApiServiceOptions.crn);
-        expect(mockRequestOptions.path.zone_id).toEqual(logpushJobsApiServiceOptions.zoneId);
-        expect(mockRequestOptions.path.job_id).toEqual(jobId);
-      }
-
-      test('should pass the right params to createRequest with enable and disable retries', () => {
-        // baseline test
-        __updateLogpushJobTest();
-
-        // enable retries and test again
-        createRequestMock.mockClear();
-        logpushJobsApiService.enableRetries();
-        __updateLogpushJobTest();
-
-        // disable retries and test again
-        createRequestMock.mockClear();
-        logpushJobsApiService.disableRetries();
-        __updateLogpushJobTest();
-      });
-
-      test('should prioritize user-given headers', () => {
-        // parameters
-        const jobId = 38;
-        const userAccept = 'fake/accept';
-        const userContentType = 'fake/contentType';
-        const updateLogpushJobParams = {
-          jobId,
-          headers: {
-            Accept: userAccept,
-            'Content-Type': userContentType,
-          },
-        };
-
-        logpushJobsApiService.updateLogpushJob(updateLogpushJobParams);
-        checkMediaHeaders(createRequestMock, userAccept, userContentType);
-      });
-    });
-
-    describe('negative tests', () => {
-      test('should enforce required parameters', async () => {
-        let err;
-        try {
-          await logpushJobsApiService.updateLogpushJob({});
-        } catch (e) {
-          err = e;
-        }
-
-        expect(err.message).toMatch(/Missing required parameters/);
-      });
-
-      test('should reject promise when required params are not given', async () => {
-        let err;
-        try {
-          await logpushJobsApiService.updateLogpushJob();
-        } catch (e) {
-          err = e;
-        }
-
-        expect(err.message).toMatch(/Missing required parameters/);
-      });
-    });
-  });
-  describe('deleteLogpushJob', () => {
-    describe('positive tests', () => {
-      function __deleteLogpushJobTest() {
-        // Construct the params object for operation deleteLogpushJob
-        const jobId = 38;
-        const deleteLogpushJobParams = {
-          jobId: jobId,
-        };
-
-        const deleteLogpushJobResult = logpushJobsApiService.deleteLogpushJob(
-          deleteLogpushJobParams
-        );
-
-        // all methods should return a Promise
-        expectToBePromise(deleteLogpushJobResult);
-
-        // assert that create request was called
-        expect(createRequestMock).toHaveBeenCalledTimes(1);
-
-        const mockRequestOptions = getOptions(createRequestMock);
-
-        checkUrlAndMethod(
-          mockRequestOptions,
-          '/v1/{crn}/zones/{zone_id}/logpush/jobs/{job_id}',
-          'DELETE'
-        );
-        const expectedAccept = 'application/json';
-        const expectedContentType = undefined;
-        checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
-        expect(mockRequestOptions.path.crn).toEqual(logpushJobsApiServiceOptions.crn);
-        expect(mockRequestOptions.path.zone_id).toEqual(logpushJobsApiServiceOptions.zoneId);
-        expect(mockRequestOptions.path.job_id).toEqual(jobId);
-      }
-
-      test('should pass the right params to createRequest with enable and disable retries', () => {
-        // baseline test
-        __deleteLogpushJobTest();
-
-        // enable retries and test again
-        createRequestMock.mockClear();
-        logpushJobsApiService.enableRetries();
-        __deleteLogpushJobTest();
-
-        // disable retries and test again
-        createRequestMock.mockClear();
-        logpushJobsApiService.disableRetries();
-        __deleteLogpushJobTest();
-      });
-
-      test('should prioritize user-given headers', () => {
-        // parameters
-        const jobId = 38;
-        const userAccept = 'fake/accept';
-        const userContentType = 'fake/contentType';
-        const deleteLogpushJobParams = {
-          jobId,
-          headers: {
-            Accept: userAccept,
-            'Content-Type': userContentType,
-          },
-        };
-
-        logpushJobsApiService.deleteLogpushJob(deleteLogpushJobParams);
-        checkMediaHeaders(createRequestMock, userAccept, userContentType);
-      });
-    });
-
-    describe('negative tests', () => {
-      test('should enforce required parameters', async () => {
-        let err;
-        try {
-          await logpushJobsApiService.deleteLogpushJob({});
-        } catch (e) {
-          err = e;
-        }
-
-        expect(err.message).toMatch(/Missing required parameters/);
-      });
-
-      test('should reject promise when required params are not given', async () => {
-        let err;
-        try {
-          await logpushJobsApiService.deleteLogpushJob();
-        } catch (e) {
-          err = e;
-        }
-
-        expect(err.message).toMatch(/Missing required parameters/);
-      });
-    });
-  });
-  describe('listFieldsForDataset', () => {
-    describe('positive tests', () => {
-      function __listFieldsForDatasetTest() {
-        // Construct the params object for operation listFieldsForDataset
-        const listFieldsForDatasetParams = {};
-
-        const listFieldsForDatasetResult = logpushJobsApiService.listFieldsForDataset(
-          listFieldsForDatasetParams
-        );
-
-        // all methods should return a Promise
-        expectToBePromise(listFieldsForDatasetResult);
-
-        // assert that create request was called
-        expect(createRequestMock).toHaveBeenCalledTimes(1);
-
-        const mockRequestOptions = getOptions(createRequestMock);
-
-        checkUrlAndMethod(
-          mockRequestOptions,
-          '/v1/{crn}/zones/{zone_id}/logpush/datasets/{dataset}/fields',
-          'GET'
-        );
-        const expectedAccept = 'application/json';
-        const expectedContentType = undefined;
-        checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
-        expect(mockRequestOptions.path.crn).toEqual(logpushJobsApiServiceOptions.crn);
-        expect(mockRequestOptions.path.zone_id).toEqual(logpushJobsApiServiceOptions.zoneId);
-        expect(mockRequestOptions.path.dataset).toEqual(logpushJobsApiServiceOptions.dataset);
-      }
-
-      test('should pass the right params to createRequest with enable and disable retries', () => {
-        // baseline test
-        __listFieldsForDatasetTest();
-
-        // enable retries and test again
-        createRequestMock.mockClear();
-        logpushJobsApiService.enableRetries();
-        __listFieldsForDatasetTest();
-
-        // disable retries and test again
-        createRequestMock.mockClear();
-        logpushJobsApiService.disableRetries();
-        __listFieldsForDatasetTest();
-      });
-
-      test('should prioritize user-given headers', () => {
-        // parameters
-        const userAccept = 'fake/accept';
-        const userContentType = 'fake/contentType';
-        const listFieldsForDatasetParams = {
-          headers: {
-            Accept: userAccept,
-            'Content-Type': userContentType,
-          },
-        };
-
-        logpushJobsApiService.listFieldsForDataset(listFieldsForDatasetParams);
-        checkMediaHeaders(createRequestMock, userAccept, userContentType);
-      });
-
-      test('should not have any problems when no parameters are passed in', () => {
-        // invoke the method with no parameters
-        logpushJobsApiService.listFieldsForDataset({});
-        checkForSuccessfulExecution(createRequestMock);
-      });
-    });
-  });
-  describe('listLogpushJobsForDataset', () => {
-    describe('positive tests', () => {
-      function __listLogpushJobsForDatasetTest() {
-        // Construct the params object for operation listLogpushJobsForDataset
-        const listLogpushJobsForDatasetParams = {};
-
-        const listLogpushJobsForDatasetResult = logpushJobsApiService.listLogpushJobsForDataset(
-          listLogpushJobsForDatasetParams
-        );
-
-        // all methods should return a Promise
-        expectToBePromise(listLogpushJobsForDatasetResult);
-
-        // assert that create request was called
-        expect(createRequestMock).toHaveBeenCalledTimes(1);
-
-        const mockRequestOptions = getOptions(createRequestMock);
-
-        checkUrlAndMethod(
-          mockRequestOptions,
-          '/v1/{crn}/zones/{zone_id}/logpush/datasets/{dataset}/jobs',
-          'GET'
-        );
-        const expectedAccept = 'application/json';
-        const expectedContentType = undefined;
-        checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
-        expect(mockRequestOptions.path.crn).toEqual(logpushJobsApiServiceOptions.crn);
-        expect(mockRequestOptions.path.zone_id).toEqual(logpushJobsApiServiceOptions.zoneId);
-        expect(mockRequestOptions.path.dataset).toEqual(logpushJobsApiServiceOptions.dataset);
-      }
-
-      test('should pass the right params to createRequest with enable and disable retries', () => {
-        // baseline test
-        __listLogpushJobsForDatasetTest();
-
-        // enable retries and test again
-        createRequestMock.mockClear();
-        logpushJobsApiService.enableRetries();
-        __listLogpushJobsForDatasetTest();
-
-        // disable retries and test again
-        createRequestMock.mockClear();
-        logpushJobsApiService.disableRetries();
-        __listLogpushJobsForDatasetTest();
-      });
-
-      test('should prioritize user-given headers', () => {
-        // parameters
-        const userAccept = 'fake/accept';
-        const userContentType = 'fake/contentType';
-        const listLogpushJobsForDatasetParams = {
-          headers: {
-            Accept: userAccept,
-            'Content-Type': userContentType,
-          },
-        };
-
-        logpushJobsApiService.listLogpushJobsForDataset(listLogpushJobsForDatasetParams);
-        checkMediaHeaders(createRequestMock, userAccept, userContentType);
-      });
-
-      test('should not have any problems when no parameters are passed in', () => {
-        // invoke the method with no parameters
-        logpushJobsApiService.listLogpushJobsForDataset({});
-        checkForSuccessfulExecution(createRequestMock);
-      });
-    });
-  });
-  describe('getLogpushOwnership', () => {
-    describe('positive tests', () => {
-      function __getLogpushOwnershipTest() {
-        // Construct the params object for operation getLogpushOwnership
-        const destinationConf =
-          'cos://cos-bucket001?region=us-south&instance-id=231f5467-3072-4cb9-9e39-a906fa3032ea';
-        const getLogpushOwnershipParams = {
-          destinationConf: destinationConf,
-        };
-
-        const getLogpushOwnershipResult = logpushJobsApiService.getLogpushOwnership(
-          getLogpushOwnershipParams
-        );
-
-        // all methods should return a Promise
-        expectToBePromise(getLogpushOwnershipResult);
-
-        // assert that create request was called
-        expect(createRequestMock).toHaveBeenCalledTimes(1);
-
-        const mockRequestOptions = getOptions(createRequestMock);
-
-        checkUrlAndMethod(
-          mockRequestOptions,
-          '/v1/{crn}/zones/{zone_id}/logpush/ownership',
-          'POST'
-        );
-        const expectedAccept = 'application/json';
-        const expectedContentType = 'application/json';
-        checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
-        expect(mockRequestOptions.body.destination_conf).toEqual(destinationConf);
-        expect(mockRequestOptions.path.crn).toEqual(logpushJobsApiServiceOptions.crn);
-        expect(mockRequestOptions.path.zone_id).toEqual(logpushJobsApiServiceOptions.zoneId);
-      }
-
-      test('should pass the right params to createRequest with enable and disable retries', () => {
-        // baseline test
-        __getLogpushOwnershipTest();
-
-        // enable retries and test again
-        createRequestMock.mockClear();
-        logpushJobsApiService.enableRetries();
-        __getLogpushOwnershipTest();
-
-        // disable retries and test again
-        createRequestMock.mockClear();
-        logpushJobsApiService.disableRetries();
-        __getLogpushOwnershipTest();
-      });
-
-      test('should prioritize user-given headers', () => {
-        // parameters
-        const userAccept = 'fake/accept';
-        const userContentType = 'fake/contentType';
-        const getLogpushOwnershipParams = {
-          headers: {
-            Accept: userAccept,
-            'Content-Type': userContentType,
-          },
-        };
-
-        logpushJobsApiService.getLogpushOwnership(getLogpushOwnershipParams);
-        checkMediaHeaders(createRequestMock, userAccept, userContentType);
-      });
-
-      test('should not have any problems when no parameters are passed in', () => {
-        // invoke the method with no parameters
-        logpushJobsApiService.getLogpushOwnership({});
-        checkForSuccessfulExecution(createRequestMock);
-      });
-    });
-  });
-  describe('validateLogpushOwnershipChallenge', () => {
-    describe('positive tests', () => {
-      function __validateLogpushOwnershipChallengeTest() {
-        // Construct the params object for operation validateLogpushOwnershipChallenge
-        const destinationConf =
-          'cos://cos-bucket001?region=us-south&instance-id=231f5467-3072-4cb9-9e39-a906fa3032ea';
-        const ownershipChallenge = '00000000000000000000';
-        const validateLogpushOwnershipChallengeParams = {
-          destinationConf: destinationConf,
-          ownershipChallenge: ownershipChallenge,
-        };
-
-        const validateLogpushOwnershipChallengeResult = logpushJobsApiService.validateLogpushOwnershipChallenge(
-          validateLogpushOwnershipChallengeParams
-        );
-
-        // all methods should return a Promise
-        expectToBePromise(validateLogpushOwnershipChallengeResult);
-
-        // assert that create request was called
-        expect(createRequestMock).toHaveBeenCalledTimes(1);
-
-        const mockRequestOptions = getOptions(createRequestMock);
-
-        checkUrlAndMethod(
-          mockRequestOptions,
-          '/v1/{crn}/zones/{zone_id}/logpush/ownership/validate',
-          'POST'
-        );
-        const expectedAccept = 'application/json';
-        const expectedContentType = 'application/json';
-        checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
-        expect(mockRequestOptions.body.destination_conf).toEqual(destinationConf);
-        expect(mockRequestOptions.body.ownership_challenge).toEqual(ownershipChallenge);
-        expect(mockRequestOptions.path.crn).toEqual(logpushJobsApiServiceOptions.crn);
-        expect(mockRequestOptions.path.zone_id).toEqual(logpushJobsApiServiceOptions.zoneId);
-      }
-
-      test('should pass the right params to createRequest with enable and disable retries', () => {
-        // baseline test
-        __validateLogpushOwnershipChallengeTest();
-
-        // enable retries and test again
-        createRequestMock.mockClear();
-        logpushJobsApiService.enableRetries();
-        __validateLogpushOwnershipChallengeTest();
-
-        // disable retries and test again
-        createRequestMock.mockClear();
-        logpushJobsApiService.disableRetries();
-        __validateLogpushOwnershipChallengeTest();
-      });
-
-      test('should prioritize user-given headers', () => {
-        // parameters
-        const userAccept = 'fake/accept';
-        const userContentType = 'fake/contentType';
-        const validateLogpushOwnershipChallengeParams = {
-          headers: {
-            Accept: userAccept,
-            'Content-Type': userContentType,
-          },
-        };
-
-        logpushJobsApiService.validateLogpushOwnershipChallenge(
-          validateLogpushOwnershipChallengeParams
-        );
-        checkMediaHeaders(createRequestMock, userAccept, userContentType);
-      });
-
-      test('should not have any problems when no parameters are passed in', () => {
-        // invoke the method with no parameters
-        logpushJobsApiService.validateLogpushOwnershipChallenge({});
-        checkForSuccessfulExecution(createRequestMock);
-      });
-    });
-  });
   describe('getLogpushJobsV2', () => {
     describe('positive tests', () => {
       function __getLogpushJobsV2Test() {
         // Construct the params object for operation getLogpushJobsV2
         const getLogpushJobsV2Params = {};
 
-        const getLogpushJobsV2Result = logpushJobsApiService.getLogpushJobsV2(
-          getLogpushJobsV2Params
-        );
+        const getLogpushJobsV2Result = logpushJobsApiService.getLogpushJobsV2(getLogpushJobsV2Params);
 
         // all methods should return a Promise
         expectToBePromise(getLogpushJobsV2Result);
@@ -911,6 +201,7 @@ describe('LogpushJobsApiV1', () => {
       });
     });
   });
+
   describe('createLogpushJobV2', () => {
     describe('positive tests', () => {
       // Request models needed by this operation.
@@ -920,7 +211,7 @@ describe('LogpushJobsApiV1', () => {
         name: 'My log push job',
         enabled: false,
         logpull_options: 'timestamps=rfc3339&timestamps=rfc3339',
-        cos: { foo: 'bar' },
+        cos: { bucket_name: 'cos-bucket001', region: 'us-south', id: '231f5467-3072-4cb9-9e39-a906fa3032ea' },
         ownership_challenge: '00000000000000000000000000000000',
         dataset: 'http_requests',
         frequency: 'high',
@@ -930,12 +221,10 @@ describe('LogpushJobsApiV1', () => {
         // Construct the params object for operation createLogpushJobV2
         const createLogpushJobV2Request = createLogpushJobV2RequestModel;
         const createLogpushJobV2Params = {
-          createLogpushJobV2Request: createLogpushJobV2Request,
+          createLogpushJobV2Request,
         };
 
-        const createLogpushJobV2Result = logpushJobsApiService.createLogpushJobV2(
-          createLogpushJobV2Params
-        );
+        const createLogpushJobV2Result = logpushJobsApiService.createLogpushJobV2(createLogpushJobV2Params);
 
         // all methods should return a Promise
         expectToBePromise(createLogpushJobV2Result);
@@ -991,13 +280,14 @@ describe('LogpushJobsApiV1', () => {
       });
     });
   });
+
   describe('getLogpushJobV2', () => {
     describe('positive tests', () => {
       function __getLogpushJobV2Test() {
         // Construct the params object for operation getLogpushJobV2
-        const jobId = 38;
+        const jobId = 'testString';
         const getLogpushJobV2Params = {
-          jobId: jobId,
+          jobId,
         };
 
         const getLogpushJobV2Result = logpushJobsApiService.getLogpushJobV2(getLogpushJobV2Params);
@@ -1010,11 +300,7 @@ describe('LogpushJobsApiV1', () => {
 
         const mockRequestOptions = getOptions(createRequestMock);
 
-        checkUrlAndMethod(
-          mockRequestOptions,
-          '/v2/{crn}/zones/{zone_id}/logpush/jobs/{job_id}',
-          'GET'
-        );
+        checkUrlAndMethod(mockRequestOptions, '/v2/{crn}/zones/{zone_id}/logpush/jobs/{job_id}', 'GET');
         const expectedAccept = 'application/json';
         const expectedContentType = undefined;
         checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
@@ -1040,7 +326,7 @@ describe('LogpushJobsApiV1', () => {
 
       test('should prioritize user-given headers', () => {
         // parameters
-        const jobId = 38;
+        const jobId = 'testString';
         const userAccept = 'fake/accept';
         const userContentType = 'fake/contentType';
         const getLogpushJobV2Params = {
@@ -1080,6 +366,7 @@ describe('LogpushJobsApiV1', () => {
       });
     });
   });
+
   describe('updateLogpushJobV2', () => {
     describe('positive tests', () => {
       // Request models needed by this operation.
@@ -1088,23 +375,21 @@ describe('LogpushJobsApiV1', () => {
       const updateLogpushJobV2RequestModel = {
         enabled: false,
         logpull_options: 'timestamps=rfc3339&timestamps=rfc3339',
-        cos: { foo: 'bar' },
+        cos: { bucket_name: 'cos-bucket001', region: 'us-south', id: '231f5467-3072-4cb9-9e39-a906fa3032ea' },
         ownership_challenge: '00000000000000000000000000000000',
         frequency: 'high',
       };
 
       function __updateLogpushJobV2Test() {
         // Construct the params object for operation updateLogpushJobV2
-        const jobId = 38;
+        const jobId = 'testString';
         const updateLogpushJobV2Request = updateLogpushJobV2RequestModel;
         const updateLogpushJobV2Params = {
-          jobId: jobId,
-          updateLogpushJobV2Request: updateLogpushJobV2Request,
+          jobId,
+          updateLogpushJobV2Request,
         };
 
-        const updateLogpushJobV2Result = logpushJobsApiService.updateLogpushJobV2(
-          updateLogpushJobV2Params
-        );
+        const updateLogpushJobV2Result = logpushJobsApiService.updateLogpushJobV2(updateLogpushJobV2Params);
 
         // all methods should return a Promise
         expectToBePromise(updateLogpushJobV2Result);
@@ -1114,11 +399,7 @@ describe('LogpushJobsApiV1', () => {
 
         const mockRequestOptions = getOptions(createRequestMock);
 
-        checkUrlAndMethod(
-          mockRequestOptions,
-          '/v2/{crn}/zones/{zone_id}/logpush/jobs/{job_id}',
-          'PUT'
-        );
+        checkUrlAndMethod(mockRequestOptions, '/v2/{crn}/zones/{zone_id}/logpush/jobs/{job_id}', 'PUT');
         const expectedAccept = 'application/json';
         const expectedContentType = 'application/json';
         checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
@@ -1145,7 +426,7 @@ describe('LogpushJobsApiV1', () => {
 
       test('should prioritize user-given headers', () => {
         // parameters
-        const jobId = 38;
+        const jobId = 'testString';
         const userAccept = 'fake/accept';
         const userContentType = 'fake/contentType';
         const updateLogpushJobV2Params = {
@@ -1185,18 +466,17 @@ describe('LogpushJobsApiV1', () => {
       });
     });
   });
+
   describe('deleteLogpushJobV2', () => {
     describe('positive tests', () => {
       function __deleteLogpushJobV2Test() {
         // Construct the params object for operation deleteLogpushJobV2
-        const jobId = 38;
+        const jobId = 'testString';
         const deleteLogpushJobV2Params = {
-          jobId: jobId,
+          jobId,
         };
 
-        const deleteLogpushJobV2Result = logpushJobsApiService.deleteLogpushJobV2(
-          deleteLogpushJobV2Params
-        );
+        const deleteLogpushJobV2Result = logpushJobsApiService.deleteLogpushJobV2(deleteLogpushJobV2Params);
 
         // all methods should return a Promise
         expectToBePromise(deleteLogpushJobV2Result);
@@ -1206,11 +486,7 @@ describe('LogpushJobsApiV1', () => {
 
         const mockRequestOptions = getOptions(createRequestMock);
 
-        checkUrlAndMethod(
-          mockRequestOptions,
-          '/v2/{crn}/zones/{zone_id}/logpush/jobs/{job_id}',
-          'DELETE'
-        );
+        checkUrlAndMethod(mockRequestOptions, '/v2/{crn}/zones/{zone_id}/logpush/jobs/{job_id}', 'DELETE');
         const expectedAccept = 'application/json';
         const expectedContentType = undefined;
         checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
@@ -1236,7 +512,7 @@ describe('LogpushJobsApiV1', () => {
 
       test('should prioritize user-given headers', () => {
         // parameters
-        const jobId = 38;
+        const jobId = 'testString';
         const userAccept = 'fake/accept';
         const userContentType = 'fake/contentType';
         const deleteLogpushJobV2Params = {
@@ -1276,18 +552,17 @@ describe('LogpushJobsApiV1', () => {
       });
     });
   });
+
   describe('getLogpushOwnershipV2', () => {
     describe('positive tests', () => {
       function __getLogpushOwnershipV2Test() {
         // Construct the params object for operation getLogpushOwnershipV2
-        const cos = { foo: 'bar' };
+        const cos = { bucket_name: 'cos-bucket001', region: 'us-south', id: '231f5467-3072-4cb9-9e39-a906fa3032ea' };
         const getLogpushOwnershipV2Params = {
-          cos: cos,
+          cos,
         };
 
-        const getLogpushOwnershipV2Result = logpushJobsApiService.getLogpushOwnershipV2(
-          getLogpushOwnershipV2Params
-        );
+        const getLogpushOwnershipV2Result = logpushJobsApiService.getLogpushOwnershipV2(getLogpushOwnershipV2Params);
 
         // all methods should return a Promise
         expectToBePromise(getLogpushOwnershipV2Result);
@@ -1297,11 +572,7 @@ describe('LogpushJobsApiV1', () => {
 
         const mockRequestOptions = getOptions(createRequestMock);
 
-        checkUrlAndMethod(
-          mockRequestOptions,
-          '/v2/{crn}/zones/{zone_id}/logpush/ownership',
-          'POST'
-        );
+        checkUrlAndMethod(mockRequestOptions, '/v2/{crn}/zones/{zone_id}/logpush/ownership', 'POST');
         const expectedAccept = 'application/json';
         const expectedContentType = 'application/json';
         checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
@@ -1347,20 +618,19 @@ describe('LogpushJobsApiV1', () => {
       });
     });
   });
+
   describe('validateLogpushOwnershipChallengeV2', () => {
     describe('positive tests', () => {
       function __validateLogpushOwnershipChallengeV2Test() {
         // Construct the params object for operation validateLogpushOwnershipChallengeV2
-        const cos = { foo: 'bar' };
+        const cos = { bucket_name: 'cos-bucket001', region: 'us-south', id: '231f5467-3072-4cb9-9e39-a906fa3032ea' };
         const ownershipChallenge = '00000000000000000000';
         const validateLogpushOwnershipChallengeV2Params = {
-          cos: cos,
-          ownershipChallenge: ownershipChallenge,
+          cos,
+          ownershipChallenge,
         };
 
-        const validateLogpushOwnershipChallengeV2Result = logpushJobsApiService.validateLogpushOwnershipChallengeV2(
-          validateLogpushOwnershipChallengeV2Params
-        );
+        const validateLogpushOwnershipChallengeV2Result = logpushJobsApiService.validateLogpushOwnershipChallengeV2(validateLogpushOwnershipChallengeV2Params);
 
         // all methods should return a Promise
         expectToBePromise(validateLogpushOwnershipChallengeV2Result);
@@ -1370,11 +640,7 @@ describe('LogpushJobsApiV1', () => {
 
         const mockRequestOptions = getOptions(createRequestMock);
 
-        checkUrlAndMethod(
-          mockRequestOptions,
-          '/v2/{crn}/zones/{zone_id}/logpush/ownership/validate',
-          'POST'
-        );
+        checkUrlAndMethod(mockRequestOptions, '/v2/{crn}/zones/{zone_id}/logpush/ownership/validate', 'POST');
         const expectedAccept = 'application/json';
         const expectedContentType = 'application/json';
         checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
@@ -1410,9 +676,7 @@ describe('LogpushJobsApiV1', () => {
           },
         };
 
-        logpushJobsApiService.validateLogpushOwnershipChallengeV2(
-          validateLogpushOwnershipChallengeV2Params
-        );
+        logpushJobsApiService.validateLogpushOwnershipChallengeV2(validateLogpushOwnershipChallengeV2Params);
         checkMediaHeaders(createRequestMock, userAccept, userContentType);
       });
 
@@ -1423,15 +687,14 @@ describe('LogpushJobsApiV1', () => {
       });
     });
   });
+
   describe('listFieldsForDatasetV2', () => {
     describe('positive tests', () => {
       function __listFieldsForDatasetV2Test() {
         // Construct the params object for operation listFieldsForDatasetV2
         const listFieldsForDatasetV2Params = {};
 
-        const listFieldsForDatasetV2Result = logpushJobsApiService.listFieldsForDatasetV2(
-          listFieldsForDatasetV2Params
-        );
+        const listFieldsForDatasetV2Result = logpushJobsApiService.listFieldsForDatasetV2(listFieldsForDatasetV2Params);
 
         // all methods should return a Promise
         expectToBePromise(listFieldsForDatasetV2Result);
@@ -1441,11 +704,7 @@ describe('LogpushJobsApiV1', () => {
 
         const mockRequestOptions = getOptions(createRequestMock);
 
-        checkUrlAndMethod(
-          mockRequestOptions,
-          '/v2/{crn}/zones/{zone_id}/logpush/datasets/{dataset}/fields',
-          'GET'
-        );
+        checkUrlAndMethod(mockRequestOptions, '/v2/{crn}/zones/{zone_id}/logpush/datasets/{dataset}/fields', 'GET');
         const expectedAccept = 'application/json';
         const expectedContentType = undefined;
         checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
@@ -1491,15 +750,14 @@ describe('LogpushJobsApiV1', () => {
       });
     });
   });
+
   describe('listLogpushJobsForDatasetV2', () => {
     describe('positive tests', () => {
       function __listLogpushJobsForDatasetV2Test() {
         // Construct the params object for operation listLogpushJobsForDatasetV2
         const listLogpushJobsForDatasetV2Params = {};
 
-        const listLogpushJobsForDatasetV2Result = logpushJobsApiService.listLogpushJobsForDatasetV2(
-          listLogpushJobsForDatasetV2Params
-        );
+        const listLogpushJobsForDatasetV2Result = logpushJobsApiService.listLogpushJobsForDatasetV2(listLogpushJobsForDatasetV2Params);
 
         // all methods should return a Promise
         expectToBePromise(listLogpushJobsForDatasetV2Result);
@@ -1509,11 +767,7 @@ describe('LogpushJobsApiV1', () => {
 
         const mockRequestOptions = getOptions(createRequestMock);
 
-        checkUrlAndMethod(
-          mockRequestOptions,
-          '/v2/{crn}/zones/{zone_id}/logpush/datasets/{dataset}/jobs',
-          'GET'
-        );
+        checkUrlAndMethod(mockRequestOptions, '/v2/{crn}/zones/{zone_id}/logpush/datasets/{dataset}/jobs', 'GET');
         const expectedAccept = 'application/json';
         const expectedContentType = undefined;
         checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
@@ -1555,6 +809,134 @@ describe('LogpushJobsApiV1', () => {
       test('should not have any problems when no parameters are passed in', () => {
         // invoke the method with no parameters
         logpushJobsApiService.listLogpushJobsForDatasetV2({});
+        checkForSuccessfulExecution(createRequestMock);
+      });
+    });
+  });
+
+  describe('getLogsRetention', () => {
+    describe('positive tests', () => {
+      function __getLogsRetentionTest() {
+        // Construct the params object for operation getLogsRetention
+        const getLogsRetentionParams = {};
+
+        const getLogsRetentionResult = logpushJobsApiService.getLogsRetention(getLogsRetentionParams);
+
+        // all methods should return a Promise
+        expectToBePromise(getLogsRetentionResult);
+
+        // assert that create request was called
+        expect(createRequestMock).toHaveBeenCalledTimes(1);
+
+        const mockRequestOptions = getOptions(createRequestMock);
+
+        checkUrlAndMethod(mockRequestOptions, '/v1/{crn}/zones/{zone_id}/logs/retention', 'GET');
+        const expectedAccept = 'application/json';
+        const expectedContentType = undefined;
+        checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
+        expect(mockRequestOptions.path.crn).toEqual(logpushJobsApiServiceOptions.crn);
+        expect(mockRequestOptions.path.zone_id).toEqual(logpushJobsApiServiceOptions.zoneId);
+      }
+
+      test('should pass the right params to createRequest with enable and disable retries', () => {
+        // baseline test
+        __getLogsRetentionTest();
+
+        // enable retries and test again
+        createRequestMock.mockClear();
+        logpushJobsApiService.enableRetries();
+        __getLogsRetentionTest();
+
+        // disable retries and test again
+        createRequestMock.mockClear();
+        logpushJobsApiService.disableRetries();
+        __getLogsRetentionTest();
+      });
+
+      test('should prioritize user-given headers', () => {
+        // parameters
+        const userAccept = 'fake/accept';
+        const userContentType = 'fake/contentType';
+        const getLogsRetentionParams = {
+          headers: {
+            Accept: userAccept,
+            'Content-Type': userContentType,
+          },
+        };
+
+        logpushJobsApiService.getLogsRetention(getLogsRetentionParams);
+        checkMediaHeaders(createRequestMock, userAccept, userContentType);
+      });
+
+      test('should not have any problems when no parameters are passed in', () => {
+        // invoke the method with no parameters
+        logpushJobsApiService.getLogsRetention({});
+        checkForSuccessfulExecution(createRequestMock);
+      });
+    });
+  });
+
+  describe('createLogRetention', () => {
+    describe('positive tests', () => {
+      function __createLogRetentionTest() {
+        // Construct the params object for operation createLogRetention
+        const flag = false;
+        const createLogRetentionParams = {
+          flag,
+        };
+
+        const createLogRetentionResult = logpushJobsApiService.createLogRetention(createLogRetentionParams);
+
+        // all methods should return a Promise
+        expectToBePromise(createLogRetentionResult);
+
+        // assert that create request was called
+        expect(createRequestMock).toHaveBeenCalledTimes(1);
+
+        const mockRequestOptions = getOptions(createRequestMock);
+
+        checkUrlAndMethod(mockRequestOptions, '/v1/{crn}/zones/{zone_id}/logs/retention', 'POST');
+        const expectedAccept = 'application/json';
+        const expectedContentType = 'application/json';
+        checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
+        expect(mockRequestOptions.body.flag).toEqual(flag);
+        expect(mockRequestOptions.path.crn).toEqual(logpushJobsApiServiceOptions.crn);
+        expect(mockRequestOptions.path.zone_id).toEqual(logpushJobsApiServiceOptions.zoneId);
+      }
+
+      test('should pass the right params to createRequest with enable and disable retries', () => {
+        // baseline test
+        __createLogRetentionTest();
+
+        // enable retries and test again
+        createRequestMock.mockClear();
+        logpushJobsApiService.enableRetries();
+        __createLogRetentionTest();
+
+        // disable retries and test again
+        createRequestMock.mockClear();
+        logpushJobsApiService.disableRetries();
+        __createLogRetentionTest();
+      });
+
+      test('should prioritize user-given headers', () => {
+        // parameters
+        const userAccept = 'fake/accept';
+        const userContentType = 'fake/contentType';
+        const createLogRetentionParams = {
+          headers: {
+            Accept: userAccept,
+            'Content-Type': userContentType,
+          },
+        };
+
+        logpushJobsApiService.createLogRetention(createLogRetentionParams);
+        checkMediaHeaders(createRequestMock, userAccept, userContentType);
+      });
+
+      test('should not have any problems when no parameters are passed in', () => {
+        // invoke the method with no parameters
+        logpushJobsApiService.createLogRetention({});
         checkForSuccessfulExecution(createRequestMock);
       });
     });


### PR DESCRIPTION
## PR summary
Fixes "unexpected EOF" error when retrieving logpush jobs configured with custom HTTP destinations. Optional fields in `LogpushJobPack` struct had incorrect `validate:"required"` tags, causing unmarshaling to fail when API returned null values.

**Fixes:** https://github.ibm.com/NetworkTribe/CIS_Support/issues/5296

## PR Checklist
Please make sure that your PR fulfills the following requirements:  
- [x] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type  
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [ ] Build/CI related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## What is the current behavior?
SDK fails to parse API responses for logpush jobs with custom HTTP destinations when optional fields (`last_complete`, `last_error`, `error_message`) contain null values. Error: "unexpected EOF" with HTTP 200 status code.

## What is the new behavior?
SDK correctly handles null values in optional fields. Logpush jobs with custom HTTP destinations can be retrieved without errors. Fields are properly marked as optional with `omitempty` JSON tags instead of `validate:"required"`.

## Does this PR introduce a breaking change?    
- [ ] Yes
- [x] No

## Other information
- Regenerated SDK with IBM OpenAPI SDK Generator v3.114.0
- All unit tests pass
- No changes to public API surface
- Backward compatible with existing code
- Related: https://github.ibm.com/NetworkTribe/ui-cli-sdk-terraform-netserv/issues/565
